### PR TITLE
SSP Integration: Smart AdServer Unit Tests to Match New Endpoint

### DIFF
--- a/adapters/smartadserver/smartadservertest/exemplary/multi-banner.json
+++ b/adapters/smartadserver/smartadservertest/exemplary/multi-banner.json
@@ -36,7 +36,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "https://ssb.smartadserver.com/api/bid?callerId=5",
+        "uri": "https://ssb.smartadserver.com/api/bid?callerId=50",
         "body": {
           "id": "test-request-multi-id",
           "imp": [
@@ -86,7 +86,7 @@
     },
     {
       "expectedRequest": {
-        "uri": "https://ssb.smartadserver.com/api/bid?callerId=5",
+        "uri": "https://ssb.smartadserver.com/api/bid?callerId=50",
         "body": {
           "id": "test-request-multi-id",
           "imp": [

--- a/adapters/smartadserver/smartadservertest/exemplary/simple-banner.json
+++ b/adapters/smartadserver/smartadservertest/exemplary/simple-banner.json
@@ -22,7 +22,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "https://ssb.smartadserver.com/api/bid?callerId=5",
+        "uri": "https://ssb.smartadserver.com/api/bid?callerId=50",
         "body": {
           "id": "test-request-id",
           "imp": [

--- a/adapters/smartadserver/smartadservertest/exemplary/simple-video.json
+++ b/adapters/smartadserver/smartadservertest/exemplary/simple-video.json
@@ -25,7 +25,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "https://ssb.smartadserver.com/api/bid?callerId=5",
+        "uri": "https://ssb.smartadserver.com/api/bid?callerId=50",
         "body": {
           "id": "test-request-id-video",
           "imp": [

--- a/adapters/smartadserver/smartadservertest/supplemental/request-site-recreated.json
+++ b/adapters/smartadserver/smartadservertest/supplemental/request-site-recreated.json
@@ -27,7 +27,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "https://ssb.smartadserver.com/api/bid?callerId=5",
+        "uri": "https://ssb.smartadserver.com/api/bid?callerId=50",
         "body": {
           "id": "test-request-id",
           "imp": [

--- a/adapters/smartadserver/smartadservertest/supplemental/response-200-without-body.json
+++ b/adapters/smartadserver/smartadservertest/supplemental/response-200-without-body.json
@@ -22,7 +22,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "https://ssb.smartadserver.com/api/bid?callerId=5",
+        "uri": "https://ssb.smartadserver.com/api/bid?callerId=50",
         "body": {
           "id": "test-request-id",
           "imp": [

--- a/adapters/smartadserver/smartadservertest/supplemental/response-204.json
+++ b/adapters/smartadserver/smartadservertest/supplemental/response-204.json
@@ -22,7 +22,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "https://ssb.smartadserver.com/api/bid?callerId=5",
+        "uri": "https://ssb.smartadserver.com/api/bid?callerId=50",
         "body": {
           "id": "test-request-id",
           "imp": [

--- a/adapters/smartadserver/smartadservertest/supplemental/response-400.json
+++ b/adapters/smartadserver/smartadservertest/supplemental/response-400.json
@@ -22,7 +22,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "https://ssb.smartadserver.com/api/bid?callerId=5",
+        "uri": "https://ssb.smartadserver.com/api/bid?callerId=50",
         "body": {
           "id": "test-request-id",
           "imp": [

--- a/adapters/smartadserver/smartadservertest/supplemental/response-500.json
+++ b/adapters/smartadserver/smartadservertest/supplemental/response-500.json
@@ -22,7 +22,7 @@
   "httpCalls": [
     {
       "expectedRequest": {
-        "uri": "https://ssb.smartadserver.com/api/bid?callerId=5",
+        "uri": "https://ssb.smartadserver.com/api/bid?callerId=50",
         "body": {
           "id": "test-request-id",
           "imp": [


### PR DESCRIPTION
Modified unit tests' reference of the endpoint to be from callerId=5 to callerId=50.