### PR TITLE
[AD-1892] Backfill ortb 2.5 params 

### DIFF
--- a/adapters/jwplayer/contentTargeting.go
+++ b/adapters/jwplayer/contentTargeting.go
@@ -41,10 +41,6 @@ type TargetingData struct {
 	TargetingProfiles []string `json:"targeting_profiles"`
 }
 
-type RTDAdapter interface {
-	EnrichRequest(request *openrtb2.BidRequest, siteId string) EnrichmentFailed
-}
-
 type ContentTargeting struct {
 	httpClient       *http.Client
 	EndpointTemplate *template.Template

--- a/adapters/jwplayer/contentTargeting.go
+++ b/adapters/jwplayer/contentTargeting.go
@@ -41,7 +41,7 @@ type TargetingData struct {
 	TargetingProfiles []string `json:"targeting_profiles"`
 }
 
-type Enricher interface {
+type RTDAdapter interface {
 	EnrichRequest(request *openrtb2.BidRequest, siteId string) EnrichmentFailed
 }
 
@@ -128,7 +128,7 @@ func (ct *ContentTargeting) enrichFields(keywords *string, content *openrtb2.Con
 	channel := make(chan TargetingOutcome, 1)
 
 	go func() {
-		response, err := ct.fetchEnrichment(targetingUrl)
+		response, err := ct.fetch(targetingUrl)
 		channel <- TargetingOutcome{
 			response: response,
 			error:    err,
@@ -158,7 +158,7 @@ func (ct *ContentTargeting) enrichFields(keywords *string, content *openrtb2.Con
 	return nil
 }
 
-func (ct *ContentTargeting) fetchEnrichment(targetingUrl string) (*TargetingResponse, *TargetingFailed) {
+func (ct *ContentTargeting) fetch(targetingUrl string) (*TargetingResponse, *TargetingFailed) {
 	httpReq, newReqErr := http.NewRequest("GET", targetingUrl, nil)
 	if newReqErr != nil {
 		return nil, &TargetingFailed{

--- a/adapters/jwplayer/contentTargetingHelpers.go
+++ b/adapters/jwplayer/contentTargetingHelpers.go
@@ -1,0 +1,56 @@
+package jwplayer
+
+import (
+	"encoding/json"
+	"github.com/prebid/prebid-server/macros"
+	"net/url"
+	"text/template"
+)
+
+func ParseExtraInfo(v string) ExtraInfo {
+	var extraInfo ExtraInfo
+	if err := json.Unmarshal([]byte(v), &extraInfo); err != nil {
+		extraInfo = ExtraInfo{}
+	}
+
+	if extraInfo.TargetingEndpoint == "" {
+		extraInfo.TargetingEndpoint = "https://content-targeting-api.longtailvideo.com/property/{{.SiteId}}/content_segments?content_url=%{{.MediaUrl}}&title={{.Title}}&description={{.Description}}"
+	}
+
+	return extraInfo
+}
+
+type EndpointTemplateParams struct {
+	SiteId      string
+	MediaUrl    string
+	Title       string
+	Description string
+}
+
+func BuildTargetingEndpoint(endpointTemplate *template.Template, siteId string, contentMetadata ContentMetadata) string {
+	if endpointTemplate == nil {
+		return ""
+	}
+
+	mediaUrl := url.QueryEscape(contentMetadata.Url)
+	title := url.QueryEscape(contentMetadata.Title)
+	description := url.QueryEscape(contentMetadata.Description)
+
+	endpointParams := EndpointTemplateParams{
+		SiteId:      siteId,
+		MediaUrl:    mediaUrl,
+		Title:       title,
+		Description: description,
+	}
+
+	reqUrl, macroResolveErr := macros.ResolveMacros(endpointTemplate, endpointParams)
+	if macroResolveErr != nil {
+		return ""
+	}
+
+	return reqUrl
+}
+
+func GetAllJwpsegs(targeting TargetingData) []string {
+	return append(targeting.BaseSegments, targeting.TargetingProfiles...)
+}

--- a/adapters/jwplayer/contentTargetingHelpers_test.go
+++ b/adapters/jwplayer/contentTargetingHelpers_test.go
@@ -1,0 +1,31 @@
+package jwplayer
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestParseExtraInfo(t *testing.T) {
+	extraInfo := ParseExtraInfo("{\"targeting_endpoint\": \"targetingUrl\"}")
+	assert.Equal(t, "targetingUrl", extraInfo.TargetingEndpoint)
+
+	defaultTargetingUrl := "https://content-targeting-api.longtailvideo.com/property/{{.SiteId}}/content_segments?content_url=%{{.MediaUrl}}&title={{.Title}}&description={{.Description}}"
+	extraInfo = ParseExtraInfo("{/")
+	assert.Equal(t, defaultTargetingUrl, extraInfo.TargetingEndpoint)
+
+	extraInfo = ParseExtraInfo("{}")
+	assert.Equal(t, defaultTargetingUrl, extraInfo.TargetingEndpoint)
+}
+
+func TestGetAllJwpsegs(t *testing.T) {
+	targetingData := TargetingData{
+		BaseSegments:      []string{"1", "2", "3"},
+		TargetingProfiles: []string{"4", "5"},
+	}
+
+	jwpsegs := GetAllJwpsegs(targetingData)
+	expectedJwpsegs := []string{"1", "2", "3", "4", "5"}
+
+	assert.Len(t, jwpsegs, len(expectedJwpsegs))
+	assert.ElementsMatch(t, jwpsegs, expectedJwpsegs)
+}

--- a/adapters/jwplayer/contentTargeting_test.go
+++ b/adapters/jwplayer/contentTargeting_test.go
@@ -43,17 +43,32 @@ func TestSuccessful(t *testing.T) {
 
 	enrichmentFailure := enricher.EnrichRequest(request, "testSiteId")
 	assert.Empty(t, enrichmentFailure)
-	assert.Equal(t, "jwpseg=1,jwpseg=2,jwpseg=3,jwpseg=4,jwpseg=5,jwpseg=6,jwpseg=7,jwpseg=8", request.App.Keywords)
-	datum := request.App.Content.Data[0]
-	assert.Equal(t, "jwplayer.com", datum.Name)
-	assert.Len(t, datum.Segment, 8)
-	expectedSegments := []openrtb2.Segment{{Value: "1"}, {Value: "2"}, {Value: "3"}, {Value: "4"}, {Value: "5"}, {Value: "6"}, {Value: "7"}, {Value: "8"}}
-	assert.ElementsMatch(t, datum.Segment, expectedSegments)
 
-	expectedExt := DataExt{Segtax: 502}
-	datumExt := DataExt{}
-	json.Unmarshal(datum.Ext, &datumExt)
-	assert.Equal(t, expectedExt, datumExt)
+	expectedEnrichedRequest := &openrtb2.BidRequest{
+		ID: "test_id",
+		Imp: []openrtb2.Imp{{
+			ID:  "test_imp_id",
+			Ext: json.RawMessage(`{"bidder":{"placementId": "test_placement_id"}}`),
+			Video: &openrtb2.Video{
+				H: 250,
+				W: 350,
+			},
+		}},
+		App: &openrtb2.App{
+			Content: &openrtb2.Content{
+				URL:   "http://www.testUrl.com/media.mp4",
+				Title: "testTitle",
+				Data: []openrtb2.Data{{
+					Name:    "jwplayer.com",
+					Segment: []openrtb2.Segment{{Value: "1"}, {Value: "2"}, {Value: "3"}, {Value: "4"}, {Value: "5"}, {Value: "6"}, {Value: "7"}, {Value: "8"}},
+					Ext:     json.RawMessage(`{"segtax":502}`),
+				}},
+				Ext: json.RawMessage(`{"description"": "testDesc"`),
+			},
+			Keywords: "jwpseg=1,jwpseg=2,jwpseg=3,jwpseg=4,jwpseg=5,jwpseg=6,jwpseg=7,jwpseg=8",
+		},
+	}
+	assert.Equal(t, expectedEnrichedRequest, request)
 }
 
 func TestSuccessfulAppendsToKeywords(t *testing.T) {
@@ -83,19 +98,34 @@ func TestSuccessfulAppendsToKeywords(t *testing.T) {
 			},
 		},
 	}
+
+	expectedRequest := &openrtb2.BidRequest{
+		ID: "test_id",
+		Imp: []openrtb2.Imp{{
+			ID:  "test_imp_id",
+			Ext: json.RawMessage(`{"bidder":{"placementId": "test_placement_id"}}`),
+			Video: &openrtb2.Video{
+				H: 250,
+				W: 350,
+			},
+		}},
+		Site: &openrtb2.Site{
+			Keywords: "existingKey=value,jwpseg=1,jwpseg=2,jwpseg=5,jwpseg=6",
+			Content: &openrtb2.Content{
+				URL:   "http://www.testUrl.com/media.mp4",
+				Title: "testTitle",
+				Data: []openrtb2.Data{{
+					Name:    "jwplayer.com",
+					Segment: []openrtb2.Segment{{Value: "1"}, {Value: "2"}, {Value: "5"}, {Value: "6"}},
+					Ext:     json.RawMessage(`{"segtax":502}`),
+				}},
+				Ext: json.RawMessage(`{"description"": "testDesc"`),
+			},
+		},
+	}
 	targetingFailure := enricher.EnrichRequest(request, "testId")
 	assert.Empty(t, targetingFailure)
-	assert.Equal(t, "existingKey=value,jwpseg=1,jwpseg=2,jwpseg=5,jwpseg=6", request.Site.Keywords)
-	datum := request.Site.Content.Data[0]
-	assert.Equal(t, "jwplayer.com", datum.Name)
-	assert.Len(t, datum.Segment, 4)
-	expectedSegments := []openrtb2.Segment{{Value: "1"}, {Value: "2"}, {Value: "5"}, {Value: "6"}}
-	assert.ElementsMatch(t, datum.Segment, expectedSegments)
-
-	expectedExt := DataExt{Segtax: 502}
-	datumExt := DataExt{}
-	json.Unmarshal(datum.Ext, &datumExt)
-	assert.Equal(t, expectedExt, datumExt)
+	assert.Equal(t, expectedRequest, request)
 }
 
 func TestSuccessAppendsToPreviousData(t *testing.T) {
@@ -131,27 +161,41 @@ func TestSuccessAppendsToPreviousData(t *testing.T) {
 			},
 		},
 	}
+
+	expectedRequest := &openrtb2.BidRequest{
+		ID: "test_id",
+		Imp: []openrtb2.Imp{{
+			ID:  "test_imp_id",
+			Ext: json.RawMessage(`{"bidder":{"placementId": "test_placement_id"}}`),
+			Video: &openrtb2.Video{
+				H: 250,
+				W: 350,
+			},
+		}},
+		Site: &openrtb2.Site{
+			Content: &openrtb2.Content{
+				URL:   "http://www.testUrl.com/media.mp4",
+				Title: "testTitle",
+				Data: []openrtb2.Data{{
+					Name: "otherData",
+					ID:   "otherDataId",
+				}, {
+					Name: "3rdData",
+					ID:   "3rdDataId",
+				}, {
+					Name:    "jwplayer.com",
+					Segment: []openrtb2.Segment{{Value: "1"}, {Value: "2"}, {Value: "5"}, {Value: "6"}},
+					Ext:     json.RawMessage(`{"segtax":502}`),
+				}},
+				Ext: json.RawMessage(`{"description"": "testDesc"`),
+			},
+			Keywords: "jwpseg=1,jwpseg=2,jwpseg=5,jwpseg=6",
+		},
+	}
+
 	targetingFailure := enricher.EnrichRequest(request, "testId")
-
 	assert.Empty(t, targetingFailure)
-	assert.Equal(t, "jwpseg=1,jwpseg=2,jwpseg=5,jwpseg=6", request.Site.Keywords)
-	assert.Len(t, request.Site.Content.Data, 3)
-	otherData := request.Site.Content.Data[0]
-	assert.Equal(t, otherData.Name, "otherData")
-	assert.Equal(t, otherData.ID, "otherDataId")
-	thirdData := request.Site.Content.Data[1]
-	assert.Equal(t, thirdData.Name, "3rdData")
-	assert.Equal(t, thirdData.ID, "3rdDataId")
-	datum := request.Site.Content.Data[2]
-	assert.Equal(t, "jwplayer.com", datum.Name)
-	assert.Len(t, datum.Segment, 4)
-	expectedSegments := []openrtb2.Segment{{Value: "1"}, {Value: "2"}, {Value: "5"}, {Value: "6"}}
-	assert.ElementsMatch(t, datum.Segment, expectedSegments)
-
-	expectedExt := DataExt{Segtax: 502}
-	datumExt := DataExt{}
-	json.Unmarshal(datum.Ext, &datumExt)
-	assert.Equal(t, expectedExt, datumExt)
+	assert.Equal(t, expectedRequest, request)
 }
 
 func TestMissingDistributionChannel(t *testing.T) {
@@ -205,10 +249,22 @@ func TestMissingContent(t *testing.T) {
 		App: &openrtb2.App{},
 	}
 
+	expectedRequest := &openrtb2.BidRequest{
+		ID: "test_id",
+		Imp: []openrtb2.Imp{{
+			ID:  "test_imp_id",
+			Ext: json.RawMessage(`{"bidder":{"placementId": "test_placement_id"}}`),
+			Video: &openrtb2.Video{
+				H: 250,
+				W: 350,
+			},
+		}},
+		App: &openrtb2.App{},
+	}
+
 	targetingFailure := enricher.EnrichRequest(request, "testSiteId")
-	assert.Empty(t, request.App.Keywords)
-	assert.Empty(t, request.App.Content)
 	assert.Equal(t, MissingContentBlockErrorCode, targetingFailure.Code())
+	assert.Equal(t, expectedRequest, request)
 }
 
 func TestDecodeError(t *testing.T) {
@@ -241,9 +297,27 @@ func TestDecodeError(t *testing.T) {
 		},
 	}
 
+	expectedRequest := &openrtb2.BidRequest{
+		ID: "test_id",
+		Imp: []openrtb2.Imp{{
+			ID:  "test_imp_id",
+			Ext: json.RawMessage(`{"bidder":{"placementId": "test_placement_id"}}`),
+			Video: &openrtb2.Video{
+				H: 250,
+				W: 350,
+			},
+		}},
+		App: &openrtb2.App{
+			Content: &openrtb2.Content{
+				URL:   "http://www.testUrl.com/media.mp4",
+				Title: "testTitle",
+				Ext:   json.RawMessage(`{"description"": "testDesc"`),
+			},
+		},
+	}
+
 	targetingFailure := enricher.EnrichRequest(request, "testSiteId")
-	assert.Empty(t, request.App.Keywords)
-	assert.Empty(t, request.App.Content.Data)
+	assert.Equal(t, expectedRequest, request)
 	assert.Equal(t, BaseDecodingErrorCode, targetingFailure.Code())
 }
 
@@ -276,9 +350,27 @@ func TestNetworkError(t *testing.T) {
 		},
 	}
 
+	expectedRequest := &openrtb2.BidRequest{
+		ID: "test_id",
+		Imp: []openrtb2.Imp{{
+			ID:  "test_imp_id",
+			Ext: json.RawMessage(`{"bidder":{"placementId": "test_placement_id"}}`),
+			Video: &openrtb2.Video{
+				H: 250,
+				W: 350,
+			},
+		}},
+		Site: &openrtb2.Site{
+			Content: &openrtb2.Content{
+				URL:   "http://www.testUrl.com/media.mp4",
+				Title: "testTitle",
+				Ext:   json.RawMessage(`{"description"": "testDesc"`),
+			},
+		},
+	}
+
 	targetingFailure := enricher.EnrichRequest(request, "testSiteId")
-	assert.Empty(t, request.Site.Keywords)
-	assert.Empty(t, request.Site.Content.Data)
+	assert.Equal(t, expectedRequest, request)
 	assert.Equal(t, BaseNetworkErrorCode+433, targetingFailure.Code())
 }
 
@@ -309,9 +401,27 @@ func TestMissingEndpoint(t *testing.T) {
 		},
 	}
 
+	expectedRequest := &openrtb2.BidRequest{
+		ID: "test_id",
+		Imp: []openrtb2.Imp{{
+			ID:  "test_imp_id",
+			Ext: json.RawMessage(`{"bidder":{"placementId": "test_placement_id"}}`),
+			Video: &openrtb2.Video{
+				H: 250,
+				W: 350,
+			},
+		}},
+		Site: &openrtb2.Site{
+			Content: &openrtb2.Content{
+				URL:   "http://www.testUrl.com/media.mp4",
+				Title: "testTitle",
+				Ext:   json.RawMessage(`{"description"": "testDesc"`),
+			},
+		},
+	}
+
 	targetingFailure := enricher.EnrichRequest(request, "testSiteId")
-	assert.Empty(t, request.Site.Keywords)
-	assert.Empty(t, request.Site.Content.Data)
+	assert.Equal(t, expectedRequest, request)
 	assert.Equal(t, TargetingUrlErrorCode, targetingFailure.Code())
 }
 
@@ -348,14 +458,72 @@ func TestRequestAlreadyHasSegments(t *testing.T) {
 		},
 	}
 
+	expectedRequest := &openrtb2.BidRequest{
+		ID: "test_id",
+		Imp: []openrtb2.Imp{{
+			ID:  "test_imp_id",
+			Ext: json.RawMessage(`{"bidder":{"placementId": "test_placement_id"}}`),
+			Video: &openrtb2.Video{
+				H: 250,
+				W: 350,
+			},
+		}},
+		Site: &openrtb2.Site{
+			Content: &openrtb2.Content{
+				URL:   "http://www.testUrl.com/media.mp4",
+				Title: "testTitle",
+				Data: []openrtb2.Data{
+					{
+						Name: "jwplayer.com",
+						Segment: []openrtb2.Segment{
+							{Value: "1"}, {Value: "2"}, {Value: "3"},
+						},
+						Ext: []byte(`{"segtax": 502}`),
+					},
+				},
+				Ext: json.RawMessage(`{"description"": "testDesc"`),
+			},
+			Keywords: "jwpseg=1,jwpseg=2,jwpseg=3",
+		},
+	}
+
 	targetingFailure := enricher.EnrichRequest(request, "testSiteId")
+	assert.Equal(t, expectedRequest, request)
 	assert.Empty(t, targetingFailure)
-	assert.Equal(t, "jwpseg=1,jwpseg=2,jwpseg=3", request.Site.Keywords)
 
 	request.Site.Keywords = "existingKey=value"
+
+	expectedRequest = &openrtb2.BidRequest{
+		ID: "test_id",
+		Imp: []openrtb2.Imp{{
+			ID:  "test_imp_id",
+			Ext: json.RawMessage(`{"bidder":{"placementId": "test_placement_id"}}`),
+			Video: &openrtb2.Video{
+				H: 250,
+				W: 350,
+			},
+		}},
+		Site: &openrtb2.Site{
+			Content: &openrtb2.Content{
+				URL:   "http://www.testUrl.com/media.mp4",
+				Title: "testTitle",
+				Data: []openrtb2.Data{
+					{
+						Name: "jwplayer.com",
+						Segment: []openrtb2.Segment{
+							{Value: "1"}, {Value: "2"}, {Value: "3"},
+						},
+						Ext: []byte(`{"segtax": 502}`),
+					},
+				},
+				Ext: json.RawMessage(`{"description"": "testDesc"`),
+			},
+			Keywords: "existingKey=value,jwpseg=1,jwpseg=2,jwpseg=3",
+		},
+	}
 	targetingFailure = enricher.EnrichRequest(request, "testSiteId")
 	assert.Empty(t, targetingFailure)
-	assert.Equal(t, "existingKey=value,jwpseg=1,jwpseg=2,jwpseg=3", request.Site.Keywords)
+	assert.Equal(t, expectedRequest, request)
 }
 
 func TestMissingSiteId(t *testing.T) {
@@ -382,9 +550,27 @@ func TestMissingSiteId(t *testing.T) {
 		},
 	}
 
+	expectedRequest := &openrtb2.BidRequest{
+		ID: "test_id",
+		Imp: []openrtb2.Imp{{
+			ID:  "test_imp_id",
+			Ext: json.RawMessage(`{"bidder":{"placementId": "test_placement_id"}}`),
+			Video: &openrtb2.Video{
+				H: 250,
+				W: 350,
+			},
+		}},
+		Site: &openrtb2.Site{
+			Content: &openrtb2.Content{
+				URL:   "http://www.testUrl.com/media.mp4",
+				Title: "testTitle",
+				Ext:   json.RawMessage(`{"description"": "testDesc"`),
+			},
+		},
+	}
+
 	targetingFailure := enricher.EnrichRequest(request, "")
-	assert.Empty(t, request.Site.Keywords)
-	assert.Empty(t, request.Site.Content.Data)
+	assert.Equal(t, expectedRequest, request)
 	assert.Equal(t, MissingSiteIdErrorCode, targetingFailure.Code())
 }
 
@@ -409,9 +595,27 @@ func TestMissingTemplate(t *testing.T) {
 		},
 	}
 
+	expectedRequest := &openrtb2.BidRequest{
+		ID: "test_id",
+		Imp: []openrtb2.Imp{{
+			ID:  "test_imp_id",
+			Ext: json.RawMessage(`{"bidder":{"placementId": "test_placement_id"}}`),
+			Video: &openrtb2.Video{
+				H: 250,
+				W: 350,
+			},
+		}},
+		Site: &openrtb2.Site{
+			Content: &openrtb2.Content{
+				URL:   "http://www.testUrl.com/media.mp4",
+				Title: "testTitle",
+				Ext:   json.RawMessage(`{"description"": "testDesc"`),
+			},
+		},
+	}
+
 	targetingFailure := enricher.EnrichRequest(request, "")
-	assert.Empty(t, request.Site.Keywords)
-	assert.Empty(t, request.Site.Content.Data)
+	assert.Equal(t, expectedRequest, request)
 	assert.Equal(t, EmptyTemplateErrorCode, targetingFailure.Code())
 }
 
@@ -438,9 +642,26 @@ func TestMissingContentUrl(t *testing.T) {
 		},
 	}
 
+	expectedRequest := &openrtb2.BidRequest{
+		ID: "test_id",
+		Imp: []openrtb2.Imp{{
+			ID:  "test_imp_id",
+			Ext: json.RawMessage(`{"bidder":{"placementId": "test_placement_id"}}`),
+			Video: &openrtb2.Video{
+				H: 250,
+				W: 350,
+			},
+		}},
+		Site: &openrtb2.Site{
+			Content: &openrtb2.Content{
+				Title: "testTitle",
+				Ext:   json.RawMessage(`{"description"": "testDesc"`),
+			},
+		},
+	}
+
 	targetingFailure := enricher.EnrichRequest(request, "testId")
-	assert.Empty(t, request.Site.Keywords)
-	assert.Empty(t, request.Site.Content.Data)
+	assert.Equal(t, expectedRequest, request)
 	assert.Equal(t, MissingMediaUrlErrorCode, targetingFailure.Code())
 }
 
@@ -470,9 +691,27 @@ func Test404(t *testing.T) {
 		},
 	}
 
+	expectedRequest := &openrtb2.BidRequest{
+		ID: "test_id",
+		Imp: []openrtb2.Imp{{
+			ID:  "test_imp_id",
+			Ext: json.RawMessage(`{"bidder":{"placementId": "test_placement_id"}}`),
+			Video: &openrtb2.Video{
+				H: 250,
+				W: 350,
+			},
+		}},
+		Site: &openrtb2.Site{
+			Content: &openrtb2.Content{
+				URL:   "http://www.testUrl.com/media.mp4",
+				Title: "testTitle",
+				Ext:   json.RawMessage(`{"description"": "testDesc"`),
+			},
+		},
+	}
+
 	targetingFailure := enricher.EnrichRequest(request, "testId")
-	assert.Empty(t, request.Site.Keywords)
-	assert.Empty(t, request.Site.Content.Data)
+	assert.Equal(t, expectedRequest, request)
 	assert.Equal(t, BaseNetworkErrorCode+404, targetingFailure.Code())
 }
 
@@ -503,8 +742,26 @@ func TestEmptySegments(t *testing.T) {
 		},
 	}
 
+	expectedRequest := &openrtb2.BidRequest{
+		ID: "test_id",
+		Imp: []openrtb2.Imp{{
+			ID:  "test_imp_id",
+			Ext: json.RawMessage(`{"bidder":{"placementId": "test_placement_id"}}`),
+			Video: &openrtb2.Video{
+				H: 250,
+				W: 350,
+			},
+		}},
+		Site: &openrtb2.Site{
+			Content: &openrtb2.Content{
+				URL:   "http://www.testUrl.com/media.mp4",
+				Title: "testTitle",
+				Ext:   json.RawMessage(`{"description"": "testDesc"`),
+			},
+		},
+	}
+
 	targetingFailure := enricher.EnrichRequest(request, "testId")
-	assert.Empty(t, request.Site.Keywords)
-	assert.Empty(t, request.Site.Content.Data)
+	assert.Equal(t, expectedRequest, request)
 	assert.Equal(t, EmptyTargetingSegmentsErrorCode, targetingFailure.Code())
 }

--- a/adapters/jwplayer/jwplayer.go
+++ b/adapters/jwplayer/jwplayer.go
@@ -261,20 +261,20 @@ func (a *Adapter) sanitizePublisher(publisher *openrtb2.Publisher) {
 func (a *Adapter) getJwplayerPublisherExt(pubExt json.RawMessage) (*jwplayerPublisher, *errortypes.BadInput) {
 	if pubExt == nil {
 		return nil, &errortypes.BadInput{
-			Message: "The bid request did not contain a publisher.ext.\n $.{site|app}.publisher.ext.jwplayer.publisherId is mandatory.",
+			Message: "The bid request is missing publisher.ext.\n $.{site|app}.publisher.ext.jwplayer.publisherId is required.",
 		}
 	}
 
 	var jwplayerPublisherExt publisherExt
 	if err := json.Unmarshal(pubExt, &jwplayerPublisherExt); err != nil {
 		return nil, &errortypes.BadInput{
-			Message: "The bid request did not contain a valid publisher.ext.jwplayer field: " + err.Error(),
+			Message: "Invalid publisher.ext.jwplayer in request: " + err.Error(),
 		}
 	}
 
 	if &jwplayerPublisherExt.JWPlayer == nil {
 		return nil, &errortypes.BadInput{
-			Message: "The bid request did is missing publisher.ext.jwplayer\n $.{site|app}.publisher.ext.jwplayer.publisherId is mandatory.",
+			Message: "The bid request is missing publisher.ext.jwplayer\n $.{site|app}.publisher.ext.jwplayer.publisherId is required.",
 		}
 	}
 

--- a/adapters/jwplayer/jwplayer.go
+++ b/adapters/jwplayer/jwplayer.go
@@ -181,7 +181,7 @@ func (a *Adapter) sanitizeImp(imp *openrtb2.Imp) *errortypes.BadInput {
 	placementId := params.PlacementId
 	imp.TagID = placementId
 	// Per results obtained when testing the bid request to Xandr, imp.ext.Appnexus.placement_id is mandatory
-	imp.Ext = GetAppnexusExt(placementId)
+	imp.Ext = GetXandrImpExt(placementId)
 	if imp.Video == nil {
 		// Per results obtained when testing the bid request to Xandr, imp.video is mandatory
 		imp.Video = &openrtb2.Video{}

--- a/adapters/jwplayer/jwplayer.go
+++ b/adapters/jwplayer/jwplayer.go
@@ -188,12 +188,6 @@ func (a *Adapter) sanitizeImp(imp *openrtb2.Imp) *errortypes.BadInput {
 	}
 
 	placementId := params.PlacementId
-	if placementId == "" {
-		return &errortypes.BadInput{
-			Message: "Empty ext.prebid.bidder.jwplayer.placementId",
-		}
-	}
-
 	imp.TagID = placementId
 	// Per results obtained when testing the bid request to Xandr, imp.ext.Appnexus.placement_id is mandatory
 	imp.Ext = GetAppnexusExt(placementId)

--- a/adapters/jwplayer/jwplayer.go
+++ b/adapters/jwplayer/jwplayer.go
@@ -84,7 +84,10 @@ func (a *Adapter) MakeRequests(request *openrtb2.BidRequest, reqInfo *adapters.E
 
 	requestCopy.Imp = validImps
 
-	var publisherParams *jwplayerPublisher
+	publisherParams := &jwplayerPublisher{
+		SiteId:      "",
+		PublisherId: "",
+	}
 
 	if site := requestCopy.Site; site != nil {
 		// per Xandr doc, if set, this should equal the Xandr placement code.

--- a/adapters/jwplayer/jwplayer.go
+++ b/adapters/jwplayer/jwplayer.go
@@ -63,13 +63,12 @@ func (a *Adapter) MakeRequests(request *openrtb2.BidRequest, reqInfo *adapters.E
 	requestCopy := *request
 	var validImps = make([]openrtb2.Imp, 0, len(request.Imp))
 
-	for _, imp := range requestCopy.Imp {
-		params, parserError := a.parseBidderParams(imp)
-		if parserError != nil {
-			errors = append(errors, parserError)
+	for idx, imp := range requestCopy.Imp {
+		err := a.sanitizeImp(&imp)
+		if err != nil {
+			err.Message = fmt.Sprintf("Imp #%d, ID %s, is invalid: %s", idx, imp.ID, err.Message)
+			errors = append(errors, err)
 		} else {
-			placementId := params.PlacementId
-			a.sanitizeImp(&imp, placementId)
 			validImps = append(validImps, imp)
 		}
 	}
@@ -179,21 +178,21 @@ func (a *Adapter) MakeBids(request *openrtb2.BidRequest, requestData *adapters.R
 	return bidderResponse, nil
 }
 
-func (a *Adapter) parseBidderParams(imp openrtb2.Imp) (*openrtb_ext.ImpExtJWPlayer, error) {
-	var impExt adapters.ExtImpBidder
-	if err := json.Unmarshal(imp.Ext, &impExt); err != nil {
-		return nil, err
+func (a *Adapter) sanitizeImp(imp *openrtb2.Imp) *errortypes.BadInput {
+	params, parseError := ParseBidderParams(*imp)
+	if parseError != nil {
+		return &errortypes.BadInput{
+			Message: "Invalid Ext: " + parseError.Error(),
+		}
 	}
 
-	var params openrtb_ext.ImpExtJWPlayer
-	if err := json.Unmarshal(impExt.Bidder, &params); err != nil {
-		return nil, err
+	placementId := params.PlacementId
+	if placementId == "" {
+		return &errortypes.BadInput{
+			Message: "Empty ext.prebid.bidder.jwplayer.placementId",
+		}
 	}
 
-	return &params, nil
-}
-
-func (a *Adapter) sanitizeImp(imp *openrtb2.Imp, placementId string) {
 	imp.TagID = placementId
 	// Per results obtained when testing the bid request to Xandr, imp.ext.Appnexus.placement_id is mandatory
 	imp.Ext = GetAppnexusExt(placementId)
@@ -201,6 +200,8 @@ func (a *Adapter) sanitizeImp(imp *openrtb2.Imp, placementId string) {
 		// Per results obtained when testing the bid request to Xandr, imp.video is mandatory
 		imp.Video = &openrtb2.Video{}
 	}
+
+	return nil
 }
 
 func (a *Adapter) sanitizeDistributionChannels(site *openrtb2.Site, app *openrtb2.App) *errortypes.BadInput {

--- a/adapters/jwplayer/jwplayer.go
+++ b/adapters/jwplayer/jwplayer.go
@@ -187,6 +187,8 @@ func (a *Adapter) sanitizeImp(imp *openrtb2.Imp) *errortypes.BadInput {
 		imp.Video = &openrtb2.Video{}
 	}
 
+	SetXandrVideoExt(imp.Video)
+
 	return nil
 }
 

--- a/adapters/jwplayer/jwplayer.go
+++ b/adapters/jwplayer/jwplayer.go
@@ -95,23 +95,14 @@ func (a *Adapter) MakeRequests(request *openrtb2.BidRequest, reqInfo *adapters.E
 	}
 
 	a.sanitizePublisher(publisher)
-	publisherParams, missingJwplayerPubExt := a.getJwplayerPublisherExt(publisher.Ext)
-	if missingJwplayerPubExt != nil {
-		errors = append(errors, missingJwplayerPubExt)
+
+	publisherParams, invalidJwplayerPubExt := a.getJwplayerPublisherExt(publisher.Ext)
+	if invalidJwplayerPubExt != nil {
+		errors = append(errors, invalidJwplayerPubExt)
 		return nil, errors
 	}
 
-	publisherId := publisherParams.PublisherId
-
-	if publisherId == "" {
-		err := &errortypes.BadInput{
-			Message: "The bid request did not contain a JWPlayer publisher Id.\n Set your Publisher Id to $.{site|app}.publisher.ext.jwplayer.publisherId.",
-		}
-		errors = append(errors, err)
-		return nil, errors
-	}
-
-	a.setSChain(&requestCopy, publisherId)
+	a.setXandrSChain(&requestCopy, publisherParams.PublisherId)
 
 	enrichmentFailure := a.enricher.EnrichRequest(&requestCopy, publisherParams.SiteId)
 	if enrichmentFailure != nil {
@@ -255,9 +246,12 @@ func (a *Adapter) sanitizePublisher(publisher *openrtb2.Publisher) {
 }
 
 func (a *Adapter) getJwplayerPublisherExt(pubExt json.RawMessage) (*jwplayerPublisher, *errortypes.BadInput) {
+	warningMessage := "The bid request is missing "
+	guidanceMessage := "\n$.{site|app}.publisher.ext.jwplayer.publisherId is required."
+
 	if pubExt == nil {
 		return nil, &errortypes.BadInput{
-			Message: "The bid request is missing publisher.ext.\n $.{site|app}.publisher.ext.jwplayer.publisherId is required.",
+			Message: warningMessage + "publisher.ext" + guidanceMessage,
 		}
 	}
 
@@ -268,23 +262,25 @@ func (a *Adapter) getJwplayerPublisherExt(pubExt json.RawMessage) (*jwplayerPubl
 		}
 	}
 
-	if &jwplayerPublisherExt.JWPlayer == nil {
+	if jwplayerPublisherExt.JWPlayer.PublisherId == "" {
 		return nil, &errortypes.BadInput{
-			Message: "The bid request is missing publisher.ext.jwplayer\n $.{site|app}.publisher.ext.jwplayer.publisherId is required.",
+			Message: warningMessage + "publisher.ext.jwplayer.publisherId" + guidanceMessage,
 		}
 	}
 
 	return &jwplayerPublisherExt.JWPlayer, nil
 }
 
-func (a *Adapter) setSChain(request *openrtb2.BidRequest, publisherId string) {
+func (a *Adapter) setXandrSChain(request *openrtb2.BidRequest, publisherId string) {
 	publisherSChain := GetPublisherSChain25(request.Source)
-	a.clearPublisherSChain(request.Source)
+	// We support request in the oRTB 2.5 format, whereas Xandr supports 2.4
+	// We discard the publisher's 2.5 schain to avoid the risk of confusion down the line for Xandr
+	a.clearPublisherSChain25(request.Source)
 	sChain := MakeSChain(publisherId, request.ID, publisherSChain)
 	request.Ext = GetXandrRequestExt(sChain)
 }
 
-func (a *Adapter) clearPublisherSChain(source *openrtb2.Source) {
+func (a *Adapter) clearPublisherSChain25(source *openrtb2.Source) {
 	if source == nil {
 		return
 	}

--- a/adapters/jwplayer/jwplayer.go
+++ b/adapters/jwplayer/jwplayer.go
@@ -30,6 +30,14 @@ type publisherExt struct {
 	JWPlayer jwplayerPublisher `json:"jwplayer,omitempty"`
 }
 
+const (
+	UnexpectedStatusCodeWarning          = "Unexpected status code:"
+	MissingFieldWarning                  = "The bid request is missing "
+	DebugSuggestion                      = "Run with request.debug = 1 for more info."
+	MissingDistributionChannelSuggestion = "Please populate either $.site or $.app."
+	MissingPublisherExtSuggestion        = "$.{site|app}.publisher.ext.jwplayer.publisherId is required."
+)
+
 // Builder builds a new instance of the JWPlayer adapter for the given bidder with the given config.
 func Builder(bidderName openrtb_ext.BidderName, config config.Adapter) (adapters.Bidder, error) {
 	//configuration is consistent with default client cache config
@@ -138,14 +146,14 @@ func (a *Adapter) MakeBids(request *openrtb2.BidRequest, requestData *adapters.R
 
 	if responseData.StatusCode == http.StatusBadRequest {
 		err := &errortypes.BadInput{
-			Message: "Unexpected status code: 400. Bad request from publisher. Run with request.debug = 1 for more info.",
+			Message: fmt.Sprintf("%s 400. Bad request from publisher. %s", UnexpectedStatusCodeWarning, DebugSuggestion),
 		}
 		return nil, []error{err}
 	}
 
 	if responseData.StatusCode != http.StatusOK {
 		err := &errortypes.BadServerResponse{
-			Message: fmt.Sprintf("Unexpected status code: %d. Run with request.debug = 1 for more info.", responseData.StatusCode),
+			Message: fmt.Sprintf("%s %d. %s", UnexpectedStatusCodeWarning, responseData.StatusCode, DebugSuggestion),
 		}
 		return nil, []error{err}
 	}
@@ -195,13 +203,13 @@ func (a *Adapter) sanitizeImp(imp *openrtb2.Imp) *errortypes.BadInput {
 func (a *Adapter) sanitizeDistributionChannels(site *openrtb2.Site, app *openrtb2.App) *errortypes.BadInput {
 	if site == nil && app == nil {
 		return &errortypes.BadInput{
-			Message: "The bid request did not contain a Site or App field. Please populate $.{site|app}.",
+			Message: fmt.Sprintf("The bid request did not contain a Site or App field. %s", MissingDistributionChannelSuggestion),
 		}
 	}
 
 	if site != nil && app != nil {
 		return &errortypes.BadInput{
-			Message: "Per oRTB 2.5, The bid request cannot contain both a Site and App field. Please populate either $.site or $.app.",
+			Message: fmt.Sprintf("Per oRTB 2.5, The bid request cannot contain both a Site and App field. %s", MissingDistributionChannelSuggestion),
 		}
 	}
 
@@ -232,7 +240,7 @@ func (a *Adapter) getPublisher(site *openrtb2.Site, app *openrtb2.App) (publishe
 
 	if publisher == nil {
 		err = &errortypes.BadInput{
-			Message: "The bid request did not contain a Publisher field. Please populate $.{site|app}.publisher .",
+			Message: MissingFieldWarning + "a Publisher field. " + MissingPublisherExtSuggestion,
 		}
 	}
 
@@ -248,12 +256,9 @@ func (a *Adapter) sanitizePublisher(publisher *openrtb2.Publisher) {
 }
 
 func (a *Adapter) getJwplayerPublisherExt(pubExt json.RawMessage) (*jwplayerPublisher, *errortypes.BadInput) {
-	warningMessage := "The bid request is missing "
-	guidanceMessage := "\n$.{site|app}.publisher.ext.jwplayer.publisherId is required."
-
 	if pubExt == nil {
 		return nil, &errortypes.BadInput{
-			Message: warningMessage + "publisher.ext" + guidanceMessage,
+			Message: MissingFieldWarning + "publisher.ext . " + MissingPublisherExtSuggestion,
 		}
 	}
 
@@ -266,7 +271,7 @@ func (a *Adapter) getJwplayerPublisherExt(pubExt json.RawMessage) (*jwplayerPubl
 
 	if jwplayerPublisherExt.JWPlayer.PublisherId == "" {
 		return nil, &errortypes.BadInput{
-			Message: warningMessage + "publisher.ext.jwplayer.publisherId" + guidanceMessage,
+			Message: MissingFieldWarning + "publisher.ext.jwplayer.publisherId . " + MissingPublisherExtSuggestion,
 		}
 	}
 

--- a/adapters/jwplayer/jwplayer.go
+++ b/adapters/jwplayer/jwplayer.go
@@ -13,8 +13,8 @@ import (
 )
 
 type Adapter struct {
-	endpoint string
-	enricher Enricher
+	endpoint   string
+	rtdAdapter RTDAdapter
 }
 
 type ExtraInfo struct {
@@ -43,16 +43,16 @@ func Builder(bidderName openrtb_ext.BidderName, config config.Adapter) (adapters
 	}
 
 	extraInfo := ParseExtraInfo(config.ExtraAdapterInfo)
-	var enricher Enricher
-	enricher, enricherBuildError := buildContentTargeting(httpClient, extraInfo.TargetingEndpoint)
+	var rtdAdapter RTDAdapter
+	rtdAdapter, rtdAdapterBuildError := buildContentTargeting(httpClient, extraInfo.TargetingEndpoint)
 
-	if enricherBuildError != nil {
-		fmt.Printf("Warning: a failure occured when building the Enricher: %s\n", enricherBuildError)
+	if rtdAdapterBuildError != nil {
+		fmt.Printf("Warning: a failure occured when building the RTDAdapter: %s\n", rtdAdapterBuildError)
 	}
 
 	bidder := &Adapter{
-		endpoint: config.Endpoint,
-		enricher: enricher,
+		endpoint:   config.Endpoint,
+		rtdAdapter: rtdAdapter,
 	}
 
 	return bidder, nil
@@ -104,7 +104,7 @@ func (a *Adapter) MakeRequests(request *openrtb2.BidRequest, reqInfo *adapters.E
 
 	a.setXandrSChain(&requestCopy, publisherParams.PublisherId)
 
-	enrichmentFailure := a.enricher.EnrichRequest(&requestCopy, publisherParams.SiteId)
+	enrichmentFailure := a.rtdAdapter.EnrichRequest(&requestCopy, publisherParams.SiteId)
 	if enrichmentFailure != nil {
 		errors = append(errors, enrichmentFailure)
 	}

--- a/adapters/jwplayer/jwplayer.go
+++ b/adapters/jwplayer/jwplayer.go
@@ -30,10 +30,6 @@ type publisherExt struct {
 	JWPlayer jwplayerPublisher `json:"jwplayer,omitempty"`
 }
 
-type requestExt struct {
-	SChain openrtb_ext.ExtRequestPrebidSChainSChain `json:"schain"`
-}
-
 // Builder builds a new instance of the JWPlayer adapter for the given bidder with the given config.
 func Builder(bidderName openrtb_ext.BidderName, config config.Adapter) (adapters.Bidder, error) {
 	//configuration is consistent with default client cache config
@@ -233,64 +229,13 @@ func (a *Adapter) sanitizePublisher(publisher *openrtb2.Publisher) {
 }
 
 func (a *Adapter) sanitizeRequestExt(request *openrtb2.BidRequest, publisherId string) {
-	schain := a.makeSChain(request, publisherId)
-	request.Ext = a.getXandrRequestExt(schain)
-}
-
-func (a *Adapter) makeSChain(request *openrtb2.BidRequest, publisherId string) openrtb_ext.ExtRequestPrebidSChainSChain {
-	node := a.makeSChainNode(publisherId, request.ID)
-	pub25SChain := a.getPublisherSChain25(*request.Source)
-	isComplete := 1
-	var nodes []*openrtb_ext.ExtRequestPrebidSChainSChainNode
-	if pub25SChain != nil {
-		isComplete = pub25SChain.Complete
-		nodes = pub25SChain.Nodes
-	}
-
-	nodes = append(nodes, &node)
-
-	return openrtb_ext.ExtRequestPrebidSChainSChain{
-		Ver:      "1.0",
-		Complete: isComplete,
-		Nodes:    nodes,
-	}
-}
-
-/*
-Get the SChain from the 2.5 oRTB spec
-*/
-func (a *Adapter) getPublisherSChain25(source openrtb2.Source) *openrtb_ext.ExtRequestPrebidSChainSChain {
-	var sourceExt openrtb_ext.SourceExt
-	if err := json.Unmarshal(source.Ext, &sourceExt); err != nil {
-		return nil
-	}
-
-	return &sourceExt.SChain
-}
-
-func (a *Adapter) makeSChainNode(publisherId string, requestId string) openrtb_ext.ExtRequestPrebidSChainSChainNode {
-	return openrtb_ext.ExtRequestPrebidSChainSChainNode{
-		ASI: jwplayerDomain,
-		SID: publisherId,
-		RID: requestId,
-		HP:  1,
-	}
-}
-
-func (a *Adapter) getXandrRequestExt(schain openrtb_ext.ExtRequestPrebidSChainSChain) []byte {
-	// Xandr expects the SChain to be in accordance with oRTB 2.4
-	// $.ext.schain
-	requestExtension := requestExt{
-		SChain: schain,
-	}
-	jsonExt, jsonError := json.Marshal(requestExtension)
-	if jsonError != nil {
-		return nil
-	}
-	return jsonExt
+	schain := MakeSChain(request, publisherId)
+	request.Ext = GetXandrRequestExt(schain)
 }
 
 func (a *Adapter) sanitizeRequest(request *openrtb2.BidRequest) {
 	// Per results obtained when testing the bid request to Xandr, $.device is mandatory
-	request.Device = &openrtb2.Device{}
+	if request.Device == nil {
+		request.Device = &openrtb2.Device{}
+	}
 }

--- a/adapters/jwplayer/jwplayer.go
+++ b/adapters/jwplayer/jwplayer.go
@@ -120,16 +120,15 @@ func (a *Adapter) MakeRequests(request *openrtb2.BidRequest, reqInfo *adapters.E
 		publisherId = publisherParams.PublisherId
 	}
 
-	// get ortb 2.4 schain if available
-	// get ortb 2.5 schain if available: $.Source.ext.schain
-	// convert to ortb 2.4
-	// append to ortb 2.4 schain if defined
-	// generate 2.4 schain node for us
-	// append to 2.4 schain: $.ext.schain
+	if publisherId == "" {
+		err := &errortypes.BadInput{
+			Message: "The bid request did not contain a publisher Id.\n Set your Publisher Id to $.{site|app}.publisher.ext.jwplayer.publisherId.",
+		}
+		errors = append(errors, err)
+		return nil, errors
+	}
 
-	// return bad input if publisherId is missing
-
-	// test: no schain , 2.4 schain, 2.5 schain
+	a.sanitizeRequestExt(&requestCopy, publisherId)
 
 	enrichmentFailure := a.enricher.EnrichRequest(&requestCopy, siteId)
 	if enrichmentFailure != nil {
@@ -229,8 +228,8 @@ func (a *Adapter) sanitizePublisher(publisher *openrtb2.Publisher) {
 }
 
 func (a *Adapter) sanitizeRequestExt(request *openrtb2.BidRequest, publisherId string) {
-	schain := MakeSChain(request, publisherId)
-	request.Ext = GetXandrRequestExt(schain)
+	sChain := MakeSChain(request, publisherId)
+	request.Ext = GetXandrRequestExt(sChain)
 }
 
 func (a *Adapter) sanitizeRequest(request *openrtb2.BidRequest) {

--- a/adapters/jwplayer/jwplayer_test.go
+++ b/adapters/jwplayer/jwplayer_test.go
@@ -66,14 +66,20 @@ func TestSingleRequest(t *testing.T) {
 		ID: "test_id",
 		Imp: []openrtb2.Imp{{
 			ID:    "test_imp_id",
-			TagID: "test_placement_id",
+			TagID: "1",
 			Video: &openrtb2.Video{
 				H: 250,
 				W: 350,
 			},
+			Ext: json.RawMessage(`{"appnexus":{"placement_id":1}}`),
 		}},
-		Site:   &openrtb2.Site{},
+		Site: &openrtb2.Site{
+			Publisher: &openrtb2.Publisher{
+				Ext: json.RawMessage((`{"jwplayer":{"publisherId":"testPublisherId"}}`)),
+			},
+		},
 		Device: &openrtb2.Device{},
+		Ext:    json.RawMessage((`{"schain":{"complete":1,"nodes":[{"asi":"jwplayer.com","sid":"testPublisherId","rid":"test_id","hp":1}],"ver":"1.0"}}`)),
 	}
 
 	assert.Equal(t, expectedJSON, processedRequestJSON)

--- a/adapters/jwplayer/jwplayer_test.go
+++ b/adapters/jwplayer/jwplayer_test.go
@@ -13,22 +13,22 @@ import (
 )
 
 func getTestAdapter() adapters.Bidder {
-	var mockEnricher Enricher = &MockEnricher{}
+	var mockRtdAdapter RTDAdapter = &MockRTDAdapter{}
 	var testAdapter adapters.Bidder = &Adapter{
-		endpoint: "http://test.com/openrtb2",
-		enricher: mockEnricher,
+		endpoint:   "http://test.com/openrtb2",
+		rtdAdapter: mockRtdAdapter,
 	}
 	return testAdapter
 }
 
-type MockEnricher struct {
+type MockRTDAdapter struct {
 	Request *openrtb2.BidRequest
 	SiteId  string
 }
 
-func (enricher *MockEnricher) EnrichRequest(request *openrtb2.BidRequest, siteId string) EnrichmentFailed {
-	enricher.Request = request
-	enricher.SiteId = siteId
+func (rtdAdapter *MockRTDAdapter) EnrichRequest(request *openrtb2.BidRequest, siteId string) EnrichmentFailed {
+	rtdAdapter.Request = request
+	rtdAdapter.SiteId = siteId
 	return nil
 }
 
@@ -526,11 +526,11 @@ func TestAppendingToExistingSchain(t *testing.T) {
 }
 
 func TestEnrichmentCall(t *testing.T) {
-	enrichmentSpy := &MockEnricher{}
-	var mockEnricher Enricher = enrichmentSpy
+	enrichmentSpy := &MockRTDAdapter{}
+	var mockRtdAdapter RTDAdapter = enrichmentSpy
 	var a adapters.Bidder = &Adapter{
-		endpoint: "http://test.com/openrtb2",
-		enricher: mockEnricher,
+		endpoint:   "http://test.com/openrtb2",
+		rtdAdapter: mockRtdAdapter,
 	}
 	var reqInfo adapters.ExtraRequestInfo
 

--- a/adapters/jwplayer/jwplayer_test.go
+++ b/adapters/jwplayer/jwplayer_test.go
@@ -195,7 +195,88 @@ func TestMandatoryRequestParamsAreAdded(t *testing.T) {
 	assert.NotNil(t, processedRequestJSON.Imp[0].Video)
 }
 
-func TestBadInputMissingPublisherId(t *testing.T) {
+func TestBadInputMissingDistributionChannel(t *testing.T) {
+	a := getTestAdapter()
+	var reqInfo adapters.ExtraRequestInfo
+
+	request := &openrtb2.BidRequest{
+		ID: "test_id",
+		Imp: []openrtb2.Imp{{
+			ID:  "test_imp_id",
+			Ext: json.RawMessage(`{"bidder":{"placementId": "test_placement_id"}}`),
+		}},
+	}
+
+	_, err := a.MakeRequests(request, &reqInfo)
+	assert.Len(t, err, 1)
+	assert.Equal(t, fmt.Sprintf("%T", &errortypes.BadInput{}), fmt.Sprintf("%T", err[0]))
+}
+
+func TestBadInputMissingPublisher(t *testing.T) {
+	a := getTestAdapter()
+	var reqInfo adapters.ExtraRequestInfo
+
+	request := &openrtb2.BidRequest{
+		ID: "test_id",
+		Imp: []openrtb2.Imp{{
+			ID:  "test_imp_id",
+			Ext: json.RawMessage(`{"bidder":{"placementId": "test_placement_id"}}`),
+		}},
+		Site: &openrtb2.Site{
+			ID: "some_id",
+		},
+	}
+
+	_, err := a.MakeRequests(request, &reqInfo)
+	assert.Len(t, err, 1)
+	assert.Equal(t, fmt.Sprintf("%T", &errortypes.BadInput{}), fmt.Sprintf("%T", err[0]))
+}
+
+func TestBadInputMissingPublisherExt(t *testing.T) {
+	a := getTestAdapter()
+	var reqInfo adapters.ExtraRequestInfo
+
+	request := &openrtb2.BidRequest{
+		ID: "test_id",
+		Imp: []openrtb2.Imp{{
+			ID:  "test_imp_id",
+			Ext: json.RawMessage(`{"bidder":{"placementId": "test_placement_id"}}`),
+		}},
+		Site: &openrtb2.Site{
+			Publisher: &openrtb2.Publisher{
+				ID: "some_pub_id",
+			},
+		},
+	}
+
+	_, err := a.MakeRequests(request, &reqInfo)
+	assert.Len(t, err, 1)
+	assert.Equal(t, fmt.Sprintf("%T", &errortypes.BadInput{}), fmt.Sprintf("%T", err[0]))
+}
+
+func TestBadInputMissingJwplayerPublisherExt(t *testing.T) {
+	a := getTestAdapter()
+	var reqInfo adapters.ExtraRequestInfo
+
+	request := &openrtb2.BidRequest{
+		ID: "test_id",
+		Imp: []openrtb2.Imp{{
+			ID:  "test_imp_id",
+			Ext: json.RawMessage(`{"bidder":{"placementId": "test_placement_id"}}`),
+		}},
+		Site: &openrtb2.Site{
+			Publisher: &openrtb2.Publisher{
+				Ext: json.RawMessage(`{"bidder":{"siteId": "testSiteId"}}`),
+			},
+		},
+	}
+
+	_, err := a.MakeRequests(request, &reqInfo)
+	assert.Len(t, err, 1)
+	assert.Equal(t, fmt.Sprintf("%T", &errortypes.BadInput{}), fmt.Sprintf("%T", err[0]))
+}
+
+func TestBadInputMissingJwplayerPublisherId(t *testing.T) {
 	a := getTestAdapter()
 	var reqInfo adapters.ExtraRequestInfo
 

--- a/adapters/jwplayer/jwplayer_test.go
+++ b/adapters/jwplayer/jwplayer_test.go
@@ -142,11 +142,11 @@ func TestInvalidImpAreFiltered(t *testing.T) {
 	assert.NotNil(t, processedRequestJSON.Imp[0].Ext, "Ext should be deleted")
 	assert.NotNil(t, processedRequestJSON.Imp[1].Ext, "Ext should be deleted")
 
-	ext1 := &appnexusImpExt{}
+	ext1 := &xandrImpExt{}
 	json.Unmarshal(processedRequestJSON.Imp[0].Ext, ext1)
 	assert.Equal(t, 1, ext1.Appnexus.PlacementID)
 
-	ext2 := &appnexusImpExt{}
+	ext2 := &xandrImpExt{}
 	json.Unmarshal(processedRequestJSON.Imp[1].Ext, ext2)
 	assert.Equal(t, 2, ext2.Appnexus.PlacementID)
 }

--- a/adapters/jwplayer/jwplayer_test.go
+++ b/adapters/jwplayer/jwplayer_test.go
@@ -40,7 +40,7 @@ func TestSingleRequest(t *testing.T) {
 		ID: "test_id",
 		Imp: []openrtb2.Imp{{
 			ID:  "test_imp_id",
-			Ext: json.RawMessage(`{"bidder":{"placementId": "test_placement_id"}}`),
+			Ext: json.RawMessage(`{"bidder":{"placementId": "1"}}`),
 			Video: &openrtb2.Video{
 				H: 250,
 				W: 350,
@@ -97,6 +97,60 @@ func TestInvalidImpExt(t *testing.T) {
 	assert.Empty(t, result, "Result should be nil")
 }
 
+func TestInvalidImpAreFiltered(t *testing.T) {
+	a := getTestAdapter()
+	var reqInfo adapters.ExtraRequestInfo
+
+	request := &openrtb2.BidRequest{
+		ID: "test_id_1",
+		Imp: []openrtb2.Imp{{
+			ID:  "test_imp_id_valid",
+			Ext: json.RawMessage(`{"bidder":{"placementId": "1"}}`),
+		}, {
+			ID:  "test_imp_id_bad_format",
+			Ext: json.RawMessage(`{]`),
+		}, {
+			ID:  "test_imp_id_valid_2",
+			Ext: json.RawMessage(`{"bidder":{"placementId": "2"}}`),
+		}, {
+			ID:  "test_imp_id_bad_missing_placementId",
+			Ext: json.RawMessage(`{"bidder":{"other": "otherId"}}`),
+		}},
+		Site: &openrtb2.Site{
+			Publisher: &openrtb2.Publisher{
+				Ext: json.RawMessage(`{"jwplayer":{"publisherId": "testPublisherId"}}`),
+			},
+		},
+	}
+
+	processedRequests, err := a.MakeRequests(request, &reqInfo)
+
+	assert.Len(t, err, 2, "2 errors should be returned")
+	assert.NotNil(t, processedRequests, "Result should be nil")
+	assert.Len(t, processedRequests, 1, "Only one request should be returned")
+
+	processedRequest := processedRequests[0]
+	processedRequestJSON := &openrtb2.BidRequest{}
+	json.Unmarshal(processedRequest.Body, processedRequestJSON)
+
+	assert.Len(t, processedRequestJSON.Imp, 2, "Imp count should be equal or less than Imps from input. In this test, should be 2.")
+	assert.Equal(t, "1", processedRequestJSON.Imp[0].TagID, "placement id should be set to TagID")
+	assert.Equal(t, "2", processedRequestJSON.Imp[1].TagID, "placement id should be set to TagID")
+	assert.NotNil(t, processedRequestJSON.Imp[0].Video, "Video should be populated")
+	assert.NotNil(t, processedRequestJSON.Imp[1].Video, "Video should be populated")
+
+	assert.NotNil(t, processedRequestJSON.Imp[0].Ext, "Ext should be deleted")
+	assert.NotNil(t, processedRequestJSON.Imp[1].Ext, "Ext should be deleted")
+
+	ext1 := &appnexusImpExt{}
+	json.Unmarshal(processedRequestJSON.Imp[0].Ext, ext1)
+	assert.Equal(t, 1, ext1.Appnexus.PlacementID)
+
+	ext2 := &appnexusImpExt{}
+	json.Unmarshal(processedRequestJSON.Imp[1].Ext, ext2)
+	assert.Equal(t, 2, ext2.Appnexus.PlacementID)
+}
+
 func TestIdsAreRemoved(t *testing.T) {
 	a := getTestAdapter()
 	var reqInfo adapters.ExtraRequestInfo
@@ -105,7 +159,7 @@ func TestIdsAreRemoved(t *testing.T) {
 		ID: "test_id",
 		Imp: []openrtb2.Imp{{
 			ID:  "test_imp_id",
-			Ext: json.RawMessage(`{"bidder":{"placementId": "test_placement_id"}}`),
+			Ext: json.RawMessage(`{"bidder":{"placementId": "1"}}`),
 		}},
 		Site: &openrtb2.Site{
 			ID:     "test_site_id",
@@ -128,7 +182,7 @@ func TestIdsAreRemoved(t *testing.T) {
 	json.Unmarshal(result.Body, resultJSON)
 
 	assert.Len(t, resultJSON.Imp, 1, "Imp count should be equal or less than Imps from input. In this test, should be 1.")
-	assert.Empty(t, resultJSON.Imp[0].Ext, "Ext should be deleted")
+	assert.NotNil(t, resultJSON.Imp[0].Ext, "Ext should be set")
 	assert.NotEmpty(t, resultJSON.Site, "Site object should not be removed")
 	assert.Empty(t, resultJSON.Site.ID, "Site.id should be removed")
 	assert.NotEmpty(t, resultJSON.Site.Publisher, "Publisher object should not be removed")
@@ -138,7 +192,7 @@ func TestIdsAreRemoved(t *testing.T) {
 		ID: "test_id",
 		Imp: []openrtb2.Imp{{
 			ID:  "test_imp_id",
-			Ext: json.RawMessage(`{"bidder":{"placementId": "test_placement_id"}}`),
+			Ext: json.RawMessage(`{"bidder":{"placementId": "1"}}`),
 		}},
 		App: &openrtb2.App{
 			ID:     "test_app_id",
@@ -161,7 +215,7 @@ func TestIdsAreRemoved(t *testing.T) {
 	json.Unmarshal(result.Body, resultJSON)
 
 	assert.Len(t, resultJSON.Imp, 1, "Imp count should be equal or less than Imps from input. In this test, should be 1.")
-	assert.Empty(t, resultJSON.Imp[0].Ext, "Ext should be deleted")
+	assert.NotNil(t, resultJSON.Imp[0].Ext, "Ext should be set")
 	assert.NotEmpty(t, resultJSON.App, "App object should not be removed")
 	assert.Empty(t, resultJSON.App.ID, "App.id should be removed")
 	assert.NotEmpty(t, resultJSON.App.Publisher, "Publisher object should not be removed")
@@ -176,7 +230,7 @@ func TestMandatoryRequestParamsAreAdded(t *testing.T) {
 		ID: "test_id",
 		Imp: []openrtb2.Imp{{
 			ID:  "test_imp_id",
-			Ext: json.RawMessage(`{"bidder":{"placementId": "test_placement_id"}}`),
+			Ext: json.RawMessage(`{"bidder":{"placementId": "1"}}`),
 		}},
 		Site: &openrtb2.Site{
 			Publisher: &openrtb2.Publisher{
@@ -203,7 +257,7 @@ func TestBadInputMissingDistributionChannel(t *testing.T) {
 		ID: "test_id",
 		Imp: []openrtb2.Imp{{
 			ID:  "test_imp_id",
-			Ext: json.RawMessage(`{"bidder":{"placementId": "test_placement_id"}}`),
+			Ext: json.RawMessage(`{"bidder":{"placementId": "1"}}`),
 		}},
 	}
 
@@ -220,7 +274,7 @@ func TestBadInputMissingPublisher(t *testing.T) {
 		ID: "test_id",
 		Imp: []openrtb2.Imp{{
 			ID:  "test_imp_id",
-			Ext: json.RawMessage(`{"bidder":{"placementId": "test_placement_id"}}`),
+			Ext: json.RawMessage(`{"bidder":{"placementId": "1"}}`),
 		}},
 		Site: &openrtb2.Site{
 			ID: "some_id",
@@ -240,7 +294,7 @@ func TestBadInputMissingPublisherExt(t *testing.T) {
 		ID: "test_id",
 		Imp: []openrtb2.Imp{{
 			ID:  "test_imp_id",
-			Ext: json.RawMessage(`{"bidder":{"placementId": "test_placement_id"}}`),
+			Ext: json.RawMessage(`{"bidder":{"placementId": "1"}}`),
 		}},
 		Site: &openrtb2.Site{
 			Publisher: &openrtb2.Publisher{
@@ -262,7 +316,7 @@ func TestBadInputMissingJwplayerPublisherExt(t *testing.T) {
 		ID: "test_id",
 		Imp: []openrtb2.Imp{{
 			ID:  "test_imp_id",
-			Ext: json.RawMessage(`{"bidder":{"placementId": "test_placement_id"}}`),
+			Ext: json.RawMessage(`{"bidder":{"placementId": "1"}}`),
 		}},
 		Site: &openrtb2.Site{
 			Publisher: &openrtb2.Publisher{
@@ -284,7 +338,7 @@ func TestBadInputMissingJwplayerPublisherId(t *testing.T) {
 		ID: "test_id",
 		Imp: []openrtb2.Imp{{
 			ID:  "test_imp_id",
-			Ext: json.RawMessage(`{"bidder":{"placementId": "test_placement_id"}}`),
+			Ext: json.RawMessage(`{"bidder":{"placementId": "1"}}`),
 		}},
 		Site: &openrtb2.Site{
 			Publisher: &openrtb2.Publisher{
@@ -306,7 +360,7 @@ func TestSChain(t *testing.T) {
 		ID: "test_id",
 		Imp: []openrtb2.Imp{{
 			ID:  "test_imp_id",
-			Ext: json.RawMessage(`{"bidder":{"placementId": "test_placement_id"}}`),
+			Ext: json.RawMessage(`{"bidder":{"placementId": "1"}}`),
 		}},
 		Site: &openrtb2.Site{
 			Publisher: &openrtb2.Publisher{
@@ -360,7 +414,7 @@ func TestAppendingToExistingSchain(t *testing.T) {
 		ID: "test_id",
 		Imp: []openrtb2.Imp{{
 			ID:  "test_imp_id",
-			Ext: json.RawMessage(`{"bidder":{"placementId": "test_placement_id"}}`),
+			Ext: json.RawMessage(`{"bidder":{"placementId": "2"}}`),
 		}},
 		Site: &openrtb2.Site{
 			Publisher: &openrtb2.Publisher{
@@ -415,7 +469,7 @@ func TestEnrichmentCall(t *testing.T) {
 		ID: "test_id",
 		Imp: []openrtb2.Imp{{
 			ID:  "test_imp_id",
-			Ext: json.RawMessage(`{"bidder":{"placementId": "test_placement_id"}}`),
+			Ext: json.RawMessage(`{"bidder":{"placementId": "2"}}`),
 			Video: &openrtb2.Video{
 				H: 250,
 				W: 350,
@@ -435,7 +489,7 @@ func TestEnrichmentCall(t *testing.T) {
 		ID: "test_id",
 		Imp: []openrtb2.Imp{{
 			ID:  "test_imp_id",
-			Ext: json.RawMessage(`{"bidder":{"placementId": "test_placement_id"}}`),
+			Ext: json.RawMessage(`{"bidder":{"placementId": "3"}}`),
 			Video: &openrtb2.Video{
 				H: 250,
 				W: 350,

--- a/adapters/jwplayer/jwplayer_test.go
+++ b/adapters/jwplayer/jwplayer_test.go
@@ -151,6 +151,39 @@ func TestInvalidImpAreFiltered(t *testing.T) {
 	assert.Equal(t, 2, ext2.Appnexus.PlacementID)
 }
 
+func TestImpVideoExt(t *testing.T) {
+	a := getTestAdapter()
+	var reqInfo adapters.ExtraRequestInfo
+
+	startDelay := openrtb2.StartDelay(50)
+	request := &openrtb2.BidRequest{
+		ID: "test_id",
+		Imp: []openrtb2.Imp{{
+			ID:  "test_imp_id",
+			Ext: json.RawMessage(`{"bidder":{"placementId": "1"}}`),
+			Video: &openrtb2.Video{
+				H:          250,
+				W:          350,
+				StartDelay: &startDelay,
+			},
+		}},
+		Site: &openrtb2.Site{
+			Publisher: &openrtb2.Publisher{
+				Ext: json.RawMessage(`{"jwplayer":{"publisherId": "testPublisherId"}}`),
+			},
+		},
+	}
+
+	processedRequests, err := a.MakeRequests(request, &reqInfo)
+
+	assert.Empty(t, err, "Errors array should be empty")
+	assert.Len(t, processedRequests, 1, "Only one request should be returned")
+
+	processedRequest := processedRequests[0]
+	processedRequestJSON := &openrtb2.BidRequest{}
+	json.Unmarshal(processedRequest.Body, processedRequestJSON)
+}
+
 func TestIdsAreRemoved(t *testing.T) {
 	a := getTestAdapter()
 	var reqInfo adapters.ExtraRequestInfo

--- a/adapters/jwplayer/jwplayer_test.go
+++ b/adapters/jwplayer/jwplayer_test.go
@@ -36,7 +36,7 @@ func TestSingleRequest(t *testing.T) {
 	a := getTestAdapter()
 	var reqInfo adapters.ExtraRequestInfo
 
-	request := &openrtb2.BidRequest{
+	rawRequest := &openrtb2.BidRequest{
 		ID: "test_id",
 		Imp: []openrtb2.Imp{{
 			ID:  "test_imp_id",
@@ -53,14 +53,14 @@ func TestSingleRequest(t *testing.T) {
 		},
 	}
 
-	processedRequests, err := a.MakeRequests(request, &reqInfo)
+	processedRequests, err := a.MakeRequests(rawRequest, &reqInfo)
 
 	assert.Empty(t, err, "Errors array should be empty")
 	assert.Len(t, processedRequests, 1, "Only one request should be returned")
 
 	processedRequest := processedRequests[0]
-	processedRequestJSON := &openrtb2.BidRequest{}
-	json.Unmarshal(processedRequest.Body, processedRequestJSON)
+	bidRequest := &openrtb2.BidRequest{}
+	json.Unmarshal(processedRequest.Body, bidRequest)
 
 	expectedJSON := &openrtb2.BidRequest{
 		ID: "test_id",
@@ -82,14 +82,14 @@ func TestSingleRequest(t *testing.T) {
 		Ext:    json.RawMessage((`{"schain":{"complete":1,"nodes":[{"asi":"jwplayer.com","sid":"testPublisherId","rid":"test_id","hp":1}],"ver":"1.0"}}`)),
 	}
 
-	assert.Equal(t, expectedJSON, processedRequestJSON)
+	assert.Equal(t, expectedJSON, bidRequest)
 }
 
 func TestInvalidImpExt(t *testing.T) {
 	a := getTestAdapter()
 	var reqInfo adapters.ExtraRequestInfo
 
-	request := &openrtb2.BidRequest{
+	rawRequest := &openrtb2.BidRequest{
 		ID: "test_id_1",
 		Imp: []openrtb2.Imp{{
 			ID:  "test_imp_id",
@@ -97,7 +97,7 @@ func TestInvalidImpExt(t *testing.T) {
 		}},
 	}
 
-	result, err := a.MakeRequests(request, &reqInfo)
+	result, err := a.MakeRequests(rawRequest, &reqInfo)
 
 	assert.Len(t, err, 2, "2 errors should be returned")
 	assert.Empty(t, result, "Result should be nil")
@@ -107,7 +107,7 @@ func TestInvalidImpAreFiltered(t *testing.T) {
 	a := getTestAdapter()
 	var reqInfo adapters.ExtraRequestInfo
 
-	request := &openrtb2.BidRequest{
+	rawRequest := &openrtb2.BidRequest{
 		ID: "test_id_1",
 		Imp: []openrtb2.Imp{{
 			ID:  "test_imp_id_valid",
@@ -124,44 +124,51 @@ func TestInvalidImpAreFiltered(t *testing.T) {
 		}},
 		Site: &openrtb2.Site{
 			Publisher: &openrtb2.Publisher{
-				Ext: json.RawMessage(`{"jwplayer":{"publisherId": "testPublisherId"}}`),
+				Ext: json.RawMessage(`{"jwplayer":{"publisherId":"testPublisherId"}}`),
 			},
 		},
 	}
 
-	processedRequests, err := a.MakeRequests(request, &reqInfo)
+	processedRequests, err := a.MakeRequests(rawRequest, &reqInfo)
 
 	assert.Len(t, err, 2, "2 errors should be returned")
-	assert.NotNil(t, processedRequests, "Result should be nil")
+	assert.NotNil(t, processedRequests, "Result should be valid. Some impressions are valid")
 	assert.Len(t, processedRequests, 1, "Only one request should be returned")
 
 	processedRequest := processedRequests[0]
 	processedRequestJSON := &openrtb2.BidRequest{}
 	json.Unmarshal(processedRequest.Body, processedRequestJSON)
 
-	assert.Len(t, processedRequestJSON.Imp, 2, "Imp count should be equal or less than Imps from input. In this test, should be 2.")
-	assert.Equal(t, "1", processedRequestJSON.Imp[0].TagID, "placement id should be set to TagID")
-	assert.Equal(t, "2", processedRequestJSON.Imp[1].TagID, "placement id should be set to TagID")
-	assert.NotNil(t, processedRequestJSON.Imp[0].Video, "Video should be populated")
-	assert.NotNil(t, processedRequestJSON.Imp[1].Video, "Video should be populated")
+	expectedRequest := &openrtb2.BidRequest{
+		ID: "test_id_1",
+		Imp: []openrtb2.Imp{{
+			ID:    "test_imp_id_valid",
+			Video: &openrtb2.Video{},
+			TagID: "1",
+			Ext:   json.RawMessage(`{"appnexus":{"placement_id":1}}`),
+		}, {
+			ID:    "test_imp_id_valid_2",
+			Video: &openrtb2.Video{},
+			TagID: "2",
+			Ext:   json.RawMessage(`{"appnexus":{"placement_id":2}}`),
+		}},
+		Site: &openrtb2.Site{
+			Publisher: &openrtb2.Publisher{
+				Ext: json.RawMessage(`{"jwplayer":{"publisherId":"testPublisherId"}}`),
+			},
+		},
+		Device: &openrtb2.Device{},
+		Ext:    json.RawMessage((`{"schain":{"complete":1,"nodes":[{"asi":"jwplayer.com","sid":"testPublisherId","rid":"test_id_1","hp":1}],"ver":"1.0"}}`)),
+	}
 
-	assert.NotNil(t, processedRequestJSON.Imp[0].Ext, "Ext should be deleted")
-	assert.NotNil(t, processedRequestJSON.Imp[1].Ext, "Ext should be deleted")
-
-	ext1 := &xandrImpExt{}
-	json.Unmarshal(processedRequestJSON.Imp[0].Ext, ext1)
-	assert.Equal(t, 1, ext1.Appnexus.PlacementID)
-
-	ext2 := &xandrImpExt{}
-	json.Unmarshal(processedRequestJSON.Imp[1].Ext, ext2)
-	assert.Equal(t, 2, ext2.Appnexus.PlacementID)
+	assert.Equal(t, expectedRequest, processedRequestJSON)
 }
 
 func TestImpVideoExt(t *testing.T) {
 	a := getTestAdapter()
 	var reqInfo adapters.ExtraRequestInfo
 
-	request := &openrtb2.BidRequest{
+	rawRequest := &openrtb2.BidRequest{
 		ID: "test_id",
 		Imp: []openrtb2.Imp{{
 			ID:  "test_imp_id",
@@ -178,53 +185,108 @@ func TestImpVideoExt(t *testing.T) {
 		},
 	}
 
-	processedRequests, err := a.MakeRequests(request, &reqInfo)
+	processedRequests, err := a.MakeRequests(rawRequest, &reqInfo)
 
 	assert.Empty(t, err, "Errors array should be empty")
 	assert.Len(t, processedRequests, 1, "Only one request should be returned")
 
 	processedRequest := processedRequests[0]
-	processedRequestJSON := &openrtb2.BidRequest{}
-	json.Unmarshal(processedRequest.Body, processedRequestJSON)
-	video := processedRequestJSON.Imp[0].Video
-	assert.Empty(t, video.Ext)
+	bidRequest := &openrtb2.BidRequest{}
+	json.Unmarshal(processedRequest.Body, bidRequest)
 
-	request.Imp[0].Video.Placement = openrtb2.VideoPlacementTypeInFeed
-	processedRequests, err = a.MakeRequests(request, &reqInfo)
+	expectedRequest := &openrtb2.BidRequest{
+		ID: "test_id",
+		Imp: []openrtb2.Imp{{
+			ID:    "test_imp_id",
+			TagID: "1",
+			Video: &openrtb2.Video{
+				H: 250,
+				W: 350,
+			},
+			Ext: json.RawMessage(`{"appnexus":{"placement_id":1}}`),
+		}},
+		Site: &openrtb2.Site{
+			Publisher: &openrtb2.Publisher{
+				Ext: json.RawMessage((`{"jwplayer":{"publisherId":"testPublisherId"}}`)),
+			},
+		},
+		Device: &openrtb2.Device{},
+		Ext:    json.RawMessage((`{"schain":{"complete":1,"nodes":[{"asi":"jwplayer.com","sid":"testPublisherId","rid":"test_id","hp":1}],"ver":"1.0"}}`)),
+	}
+
+	assert.Equal(t, expectedRequest, bidRequest)
+
+	rawRequest.Imp[0].Video.Placement = openrtb2.VideoPlacementTypeInFeed
+	processedRequests, err = a.MakeRequests(rawRequest, &reqInfo)
 
 	assert.Empty(t, err, "Errors array should be empty")
 	assert.Len(t, processedRequests, 1, "Only one request should be returned")
 
 	processedRequest = processedRequests[0]
-	json.Unmarshal(processedRequest.Body, processedRequestJSON)
-	video = processedRequestJSON.Imp[0].Video
-	assert.NotNil(t, video.Ext)
+	json.Unmarshal(processedRequest.Body, bidRequest)
 
-	var ext xandrVideoExt
-	json.Unmarshal(video.Ext, &ext)
-	assert.Equal(t, Outstream, ext.Appnexus.Context)
+	expectedRequest = &openrtb2.BidRequest{
+		ID: "test_id",
+		Imp: []openrtb2.Imp{{
+			ID:    "test_imp_id",
+			TagID: "1",
+			Video: &openrtb2.Video{
+				H:         250,
+				W:         350,
+				Placement: openrtb2.VideoPlacementTypeInFeed,
+				Ext:       json.RawMessage(`{"appnexus":{"context":4}}`),
+			},
+			Ext: json.RawMessage(`{"appnexus":{"placement_id":1}}`),
+		}},
+		Site: &openrtb2.Site{
+			Publisher: &openrtb2.Publisher{
+				Ext: json.RawMessage((`{"jwplayer":{"publisherId":"testPublisherId"}}`)),
+			},
+		},
+		Device: &openrtb2.Device{},
+		Ext:    json.RawMessage((`{"schain":{"complete":1,"nodes":[{"asi":"jwplayer.com","sid":"testPublisherId","rid":"test_id","hp":1}],"ver":"1.0"}}`)),
+	}
 
-	request.Imp[0].Video.Placement = openrtb2.VideoPlacementTypeInStream
-	request.Imp[0].Video.StartDelay = openrtb2.StartDelay(10).Ptr()
-	processedRequests, err = a.MakeRequests(request, &reqInfo)
+	assert.Equal(t, expectedRequest, bidRequest)
 
-	assert.Empty(t, err, "Errors array should be empty")
-	assert.Len(t, processedRequests, 1, "Only one request should be returned")
+	rawRequest.Imp[0].Video.Placement = openrtb2.VideoPlacementTypeInStream
+	rawRequest.Imp[0].Video.StartDelay = openrtb2.StartDelay(10).Ptr()
+	processedRequests, err = a.MakeRequests(rawRequest, &reqInfo)
 
 	processedRequest = processedRequests[0]
-	json.Unmarshal(processedRequest.Body, processedRequestJSON)
-	video = processedRequestJSON.Imp[0].Video
-	assert.NotNil(t, video.Ext)
+	json.Unmarshal(processedRequest.Body, bidRequest)
 
-	json.Unmarshal(video.Ext, &ext)
-	assert.Equal(t, MidRoll, ext.Appnexus.Context)
+	expectedRequest = &openrtb2.BidRequest{
+		ID: "test_id",
+		Imp: []openrtb2.Imp{{
+			ID:    "test_imp_id",
+			TagID: "1",
+			Video: &openrtb2.Video{
+				H:          250,
+				W:          350,
+				Placement:  openrtb2.VideoPlacementTypeInStream,
+				StartDelay: openrtb2.StartDelay(10).Ptr(),
+				Ext:        json.RawMessage(`{"appnexus":{"context":2}}`),
+			},
+			Ext: json.RawMessage(`{"appnexus":{"placement_id":1}}`),
+		}},
+		Site: &openrtb2.Site{
+			Publisher: &openrtb2.Publisher{
+				Ext: json.RawMessage((`{"jwplayer":{"publisherId":"testPublisherId"}}`)),
+			},
+		},
+		Device: &openrtb2.Device{},
+		Ext:    json.RawMessage((`{"schain":{"complete":1,"nodes":[{"asi":"jwplayer.com","sid":"testPublisherId","rid":"test_id","hp":1}],"ver":"1.0"}}`)),
+	}
+
+	assert.Equal(t, expectedRequest, bidRequest)
 }
 
 func TestIdsAreRemoved(t *testing.T) {
 	a := getTestAdapter()
 	var reqInfo adapters.ExtraRequestInfo
 
-	request := &openrtb2.BidRequest{
+	rawRequest := &openrtb2.BidRequest{
 		ID: "test_id",
 		Imp: []openrtb2.Imp{{
 			ID:  "test_imp_id",
@@ -241,23 +303,37 @@ func TestIdsAreRemoved(t *testing.T) {
 		},
 	}
 
-	processedRequest, err := a.MakeRequests(request, &reqInfo)
+	processedRequests, err := a.MakeRequests(rawRequest, &reqInfo)
 
 	assert.Empty(t, err, "Errors array should be empty")
-	assert.Len(t, processedRequest, 1, "Only one request should be returned")
+	assert.Len(t, processedRequests, 1, "Only one request should be returned")
 
-	result := processedRequest[0]
-	resultJSON := &openrtb2.BidRequest{}
-	json.Unmarshal(result.Body, resultJSON)
+	request := processedRequests[0]
+	bidRequest := &openrtb2.BidRequest{}
+	json.Unmarshal(request.Body, bidRequest)
 
-	assert.Len(t, resultJSON.Imp, 1, "Imp count should be equal or less than Imps from input. In this test, should be 1.")
-	assert.NotNil(t, resultJSON.Imp[0].Ext, "Ext should be set")
-	assert.NotEmpty(t, resultJSON.Site, "Site object should not be removed")
-	assert.Empty(t, resultJSON.Site.ID, "Site.id should be removed")
-	assert.NotEmpty(t, resultJSON.Site.Publisher, "Publisher object should not be removed")
-	assert.Empty(t, resultJSON.Site.Publisher.ID, "Publisher.id should be removed")
+	expectedRequest := &openrtb2.BidRequest{
+		ID: "test_id",
+		Imp: []openrtb2.Imp{{
+			ID:    "test_imp_id",
+			TagID: "1",
+			Video: &openrtb2.Video{},
+			Ext:   json.RawMessage(`{"appnexus":{"placement_id":1}}`),
+		}},
+		Site: &openrtb2.Site{
+			Domain: "test_domain",
+			Publisher: &openrtb2.Publisher{
+				Name: "testPublisher_name",
+				Ext:  json.RawMessage((`{"jwplayer":{"publisherId":"testPublisherId"}}`)),
+			},
+		},
+		Device: &openrtb2.Device{},
+		Ext:    json.RawMessage((`{"schain":{"complete":1,"nodes":[{"asi":"jwplayer.com","sid":"testPublisherId","rid":"test_id","hp":1}],"ver":"1.0"}}`)),
+	}
 
-	request = &openrtb2.BidRequest{
+	assert.Equal(t, expectedRequest, bidRequest)
+
+	rawRequest = &openrtb2.BidRequest{
 		ID: "test_id",
 		Imp: []openrtb2.Imp{{
 			ID:  "test_imp_id",
@@ -274,28 +350,42 @@ func TestIdsAreRemoved(t *testing.T) {
 		},
 	}
 
-	processedRequest, err = a.MakeRequests(request, &reqInfo)
+	processedRequests, err = a.MakeRequests(rawRequest, &reqInfo)
 
 	assert.Empty(t, err, "Errors array should be empty")
-	assert.Len(t, processedRequest, 1, "Only one request should be returned")
+	assert.Len(t, processedRequests, 1, "Only one request should be returned")
 
-	result = processedRequest[0]
-	resultJSON = &openrtb2.BidRequest{}
-	json.Unmarshal(result.Body, resultJSON)
+	request = processedRequests[0]
+	bidRequest = &openrtb2.BidRequest{}
+	json.Unmarshal(request.Body, bidRequest)
 
-	assert.Len(t, resultJSON.Imp, 1, "Imp count should be equal or less than Imps from input. In this test, should be 1.")
-	assert.NotNil(t, resultJSON.Imp[0].Ext, "Ext should be set")
-	assert.NotEmpty(t, resultJSON.App, "App object should not be removed")
-	assert.Empty(t, resultJSON.App.ID, "App.id should be removed")
-	assert.NotEmpty(t, resultJSON.App.Publisher, "Publisher object should not be removed")
-	assert.Empty(t, resultJSON.App.Publisher.ID, "Publisher.id should be removed")
+	expectedRequest = &openrtb2.BidRequest{
+		ID: "test_id",
+		Imp: []openrtb2.Imp{{
+			ID:    "test_imp_id",
+			TagID: "1",
+			Video: &openrtb2.Video{},
+			Ext:   json.RawMessage(`{"appnexus":{"placement_id":1}}`),
+		}},
+		App: &openrtb2.App{
+			Domain: "test_app_domain",
+			Publisher: &openrtb2.Publisher{
+				Name: "testPublisher_name",
+				Ext:  json.RawMessage(`{"jwplayer":{"publisherId":"testPublisherId"}}`),
+			},
+		},
+		Device: &openrtb2.Device{},
+		Ext:    json.RawMessage((`{"schain":{"complete":1,"nodes":[{"asi":"jwplayer.com","sid":"testPublisherId","rid":"test_id","hp":1}],"ver":"1.0"}}`)),
+	}
+
+	assert.Equal(t, expectedRequest, bidRequest)
 }
 
 func TestMandatoryRequestParamsAreAdded(t *testing.T) {
 	a := getTestAdapter()
 	var reqInfo adapters.ExtraRequestInfo
 
-	request := &openrtb2.BidRequest{
+	rawRequest := &openrtb2.BidRequest{
 		ID: "test_id",
 		Imp: []openrtb2.Imp{{
 			ID:  "test_imp_id",
@@ -308,14 +398,30 @@ func TestMandatoryRequestParamsAreAdded(t *testing.T) {
 		},
 	}
 
-	processedRequests, err := a.MakeRequests(request, &reqInfo)
+	processedRequests, err := a.MakeRequests(rawRequest, &reqInfo)
 	assert.Empty(t, err)
 
 	processedRequest := processedRequests[0]
-	processedRequestJSON := &openrtb2.BidRequest{}
-	json.Unmarshal(processedRequest.Body, processedRequestJSON)
-	assert.NotNil(t, processedRequestJSON.Device)
-	assert.NotNil(t, processedRequestJSON.Imp[0].Video)
+	bidRequest := &openrtb2.BidRequest{}
+	json.Unmarshal(processedRequest.Body, bidRequest)
+
+	expectedRequest := &openrtb2.BidRequest{
+		ID: "test_id",
+		Imp: []openrtb2.Imp{{
+			ID:    "test_imp_id",
+			TagID: "1",
+			Video: &openrtb2.Video{},
+			Ext:   json.RawMessage(`{"appnexus":{"placement_id":1}}`),
+		}},
+		Site: &openrtb2.Site{
+			Publisher: &openrtb2.Publisher{
+				Ext: json.RawMessage((`{"jwplayer":{"publisherId":"testPublisherId"}}`)),
+			},
+		},
+		Device: &openrtb2.Device{},
+		Ext:    json.RawMessage((`{"schain":{"complete":1,"nodes":[{"asi":"jwplayer.com","sid":"testPublisherId","rid":"test_id","hp":1}],"ver":"1.0"}}`)),
+	}
+	assert.Equal(t, expectedRequest, bidRequest)
 }
 
 func TestBadInputMissingDistributionChannel(t *testing.T) {
@@ -425,7 +531,7 @@ func TestSChain(t *testing.T) {
 	a := getTestAdapter()
 	var reqInfo adapters.ExtraRequestInfo
 
-	request := &openrtb2.BidRequest{
+	rawRequest := &openrtb2.BidRequest{
 		ID: "test_id",
 		Imp: []openrtb2.Imp{{
 			ID:  "test_imp_id",
@@ -438,26 +544,30 @@ func TestSChain(t *testing.T) {
 		},
 	}
 
-	processedRequests, err := a.MakeRequests(request, &reqInfo)
+	processedRequests, err := a.MakeRequests(rawRequest, &reqInfo)
 	assert.Empty(t, err)
 
 	processedRequest := processedRequests[0]
-	processedRequestJSON := &openrtb2.BidRequest{}
-	json.Unmarshal(processedRequest.Body, processedRequestJSON)
-	assert.NotNil(t, processedRequestJSON.Ext)
-	var requestExtJSON requestExt
-	parseErr := json.Unmarshal(processedRequestJSON.Ext, &requestExtJSON)
-	assert.Nil(t, parseErr)
-	assert.NotNil(t, requestExtJSON.SChain)
-	sChain := requestExtJSON.SChain
-	assert.Equal(t, 1, sChain.Complete)
-	assert.Equal(t, "1.0", sChain.Ver)
-	assert.Len(t, sChain.Nodes, 1)
-	node := sChain.Nodes[0]
-	assert.Equal(t, jwplayerDomain, node.ASI)
-	assert.Equal(t, "testPublisherId", node.SID)
-	assert.Equal(t, "test_id", node.RID)
-	assert.Equal(t, 1, node.HP)
+	bidRequest := &openrtb2.BidRequest{}
+	json.Unmarshal(processedRequest.Body, bidRequest)
+
+	expectedRequest := &openrtb2.BidRequest{
+		ID: "test_id",
+		Imp: []openrtb2.Imp{{
+			ID:    "test_imp_id",
+			TagID: "1",
+			Video: &openrtb2.Video{},
+			Ext:   json.RawMessage(`{"appnexus":{"placement_id":1}}`),
+		}},
+		Site: &openrtb2.Site{
+			Publisher: &openrtb2.Publisher{
+				Ext: json.RawMessage((`{"jwplayer":{"publisherId":"testPublisherId"}}`)),
+			},
+		},
+		Device: &openrtb2.Device{},
+		Ext:    json.RawMessage((`{"schain":{"complete":1,"nodes":[{"asi":"jwplayer.com","sid":"testPublisherId","rid":"test_id","hp":1}],"ver":"1.0"}}`)),
+	}
+	assert.Equal(t, expectedRequest, bidRequest)
 }
 
 func TestAppendingToExistingSchain(t *testing.T) {
@@ -479,7 +589,7 @@ func TestAppendingToExistingSchain(t *testing.T) {
 
 	sourceExtJSON, _ := json.Marshal(sourceExt)
 
-	request := &openrtb2.BidRequest{
+	rawRequest := &openrtb2.BidRequest{
 		ID: "test_id",
 		Imp: []openrtb2.Imp{{
 			ID:  "test_imp_id",
@@ -495,34 +605,32 @@ func TestAppendingToExistingSchain(t *testing.T) {
 		},
 	}
 
-	processedRequests, err := a.MakeRequests(request, &reqInfo)
+	processedRequests, err := a.MakeRequests(rawRequest, &reqInfo)
 	assert.Empty(t, err)
 
 	processedRequest := processedRequests[0]
-	processedRequestJSON := &openrtb2.BidRequest{}
-	json.Unmarshal(processedRequest.Body, processedRequestJSON)
-	assert.NotNil(t, processedRequestJSON.Ext)
+	bidRequest := &openrtb2.BidRequest{}
+	json.Unmarshal(processedRequest.Body, bidRequest)
 
-	var requestExtJSON requestExt
-	parseErr := json.Unmarshal(processedRequestJSON.Ext, &requestExtJSON)
-	assert.Nil(t, parseErr)
-	assert.NotNil(t, requestExtJSON.SChain)
-	sChain := requestExtJSON.SChain
-	assert.Equal(t, 0, sChain.Complete)
-	assert.Equal(t, "1.0", sChain.Ver)
-	assert.Len(t, sChain.Nodes, 2)
+	expectedRequest := &openrtb2.BidRequest{
+		ID: "test_id",
+		Imp: []openrtb2.Imp{{
+			ID:    "test_imp_id",
+			TagID: "2",
+			Video: &openrtb2.Video{},
+			Ext:   json.RawMessage(`{"appnexus":{"placement_id":2}}`),
+		}},
+		Site: &openrtb2.Site{
+			Publisher: &openrtb2.Publisher{
+				Ext: json.RawMessage((`{"jwplayer":{"publisherId":"testPublisherId"}}`)),
+			},
+		},
+		Source: &openrtb2.Source{},
+		Device: &openrtb2.Device{},
+		Ext:    json.RawMessage((`{"schain":{"complete":0,"nodes":[{"asi":"publisher.com","sid":"some id","rid":"some req id","hp":0},{"asi":"jwplayer.com","sid":"testPublisherId","rid":"test_id","hp":1}],"ver":"1.0"}}`)),
+	}
 
-	publisherNode := sChain.Nodes[0]
-	assert.Equal(t, "publisher.com", publisherNode.ASI)
-	assert.Equal(t, "some id", publisherNode.SID)
-	assert.Equal(t, "some req id", publisherNode.RID)
-	assert.Equal(t, 0, publisherNode.HP)
-
-	jwplayerNode := sChain.Nodes[1]
-	assert.Equal(t, jwplayerDomain, jwplayerNode.ASI)
-	assert.Equal(t, "testPublisherId", jwplayerNode.SID)
-	assert.Equal(t, "test_id", jwplayerNode.RID)
-	assert.Equal(t, 1, jwplayerNode.HP)
+	assert.Equal(t, expectedRequest, bidRequest)
 }
 
 func TestEnrichmentCall(t *testing.T) {
@@ -599,10 +707,27 @@ func TestSourceSanitization(t *testing.T) {
 	assert.Empty(t, err)
 
 	processedRequest := processedRequests[0]
-	processedRequestJSON := &openrtb2.BidRequest{}
-	json.Unmarshal(processedRequest.Body, processedRequestJSON)
-	assert.NotNil(t, processedRequestJSON.Source)
-	assert.Empty(t, processedRequestJSON.Source.Ext)
+	bidRequest := &openrtb2.BidRequest{}
+	json.Unmarshal(processedRequest.Body, bidRequest)
+
+	expectedRequest := &openrtb2.BidRequest{
+		ID: "test_id",
+		Imp: []openrtb2.Imp{{
+			ID:    "test_imp_id",
+			TagID: "1",
+			Video: &openrtb2.Video{},
+			Ext:   json.RawMessage(`{"appnexus":{"placement_id":1}}`),
+		}},
+		Site: &openrtb2.Site{
+			Publisher: &openrtb2.Publisher{
+				Ext: json.RawMessage((`{"jwplayer":{"publisherId":"testPublisherId"}}`)),
+			},
+		},
+		Source: &openrtb2.Source{},
+		Device: &openrtb2.Device{},
+		Ext:    json.RawMessage((`{"schain":{"complete":1,"nodes":[{"asi":"jwplayer.com","sid":"testPublisherId","rid":"test_id","hp":1}],"ver":"1.0"}}`)),
+	}
+	assert.Equal(t, expectedRequest, bidRequest)
 }
 
 func TestOpenRTBEmptyResponse(t *testing.T) {

--- a/adapters/jwplayer/ortbHelpers.go
+++ b/adapters/jwplayer/ortbHelpers.go
@@ -1,0 +1,129 @@
+package jwplayer
+
+import (
+	"encoding/json"
+	"github.com/mxmCherry/openrtb/v15/openrtb2"
+	"github.com/prebid/prebid-server/adapters"
+	"github.com/prebid/prebid-server/errortypes"
+	"github.com/prebid/prebid-server/openrtb_ext"
+)
+
+func ParseBidderParams(imp openrtb2.Imp) (*openrtb_ext.ImpExtJWPlayer, error) {
+	var impExt adapters.ExtImpBidder
+	if err := json.Unmarshal(imp.Ext, &impExt); err != nil {
+		return nil, err
+	}
+
+	var params *openrtb_ext.ImpExtJWPlayer
+	if err := json.Unmarshal(impExt.Bidder, &params); err != nil {
+		return nil, err
+	}
+
+	if params.PlacementId == "" {
+		return nil, &errortypes.BadInput{
+			Message: "Empty ext.prebid.bidder.jwplayer.placementId",
+		}
+	}
+
+	return params, nil
+}
+
+func ParseContentMetadata(content openrtb2.Content) ContentMetadata {
+	metadata := ContentMetadata{
+		Url:   content.URL,
+		Title: content.Title,
+	}
+
+	contentExt := ContentExt{}
+	if error := json.Unmarshal(content.Ext, &contentExt); error == nil {
+		metadata.Description = contentExt.Description
+	}
+
+	return metadata
+}
+
+func GetExistingJwpsegs(data []openrtb2.Data) []string {
+	for _, datum := range data {
+		if HasJwpsegs(datum) {
+			return ParseJwpsegs(datum.Segment)
+		}
+	}
+
+	return nil
+}
+
+func HasJwpsegs(datum openrtb2.Data) bool {
+	dataExt := DataExt{}
+	if error := json.Unmarshal(datum.Ext, &dataExt); error != nil {
+		return false
+	}
+
+	return datum.Name == jwplayerDomain && dataExt.Segtax == jwplayerSegtax && len(datum.Segment) > 0
+}
+
+func ParseJwpsegs(segments []openrtb2.Segment) []string {
+	segmentToJwpseg := func(segment openrtb2.Segment) string { return segment.Value }
+	jwpsegs := Map(segments, segmentToJwpseg)
+	return jwpsegs
+}
+
+func MakeOrtbDatum(jwpsegs []string) (contentData openrtb2.Data) {
+	contentData.Name = jwplayerDomain
+	contentData.Segment = MakeOrtbSegments(jwpsegs)
+	dataExt := DataExt{
+		Segtax: jwplayerSegtax,
+	}
+	contentData.Ext, _ = json.Marshal(dataExt)
+	return contentData
+}
+
+func MakeOrtbSegments(jwpsegs []string) []openrtb2.Segment {
+	jwpsegToSegment := func(jwpseg string) openrtb2.Segment { return openrtb2.Segment{Value: jwpseg} }
+	segments := Map(jwpsegs, jwpsegToSegment)
+	return segments
+}
+
+type requestExt struct {
+	SChain openrtb_ext.ExtRequestPrebidSChainSChain `json:"schain"`
+}
+
+func MakeSChain(publisherId string, requestId string, publisherSChain *openrtb_ext.ExtRequestPrebidSChainSChain) openrtb_ext.ExtRequestPrebidSChainSChain {
+	node := MakeSChainNode(publisherId, requestId)
+	isComplete := 1
+	var nodes []*openrtb_ext.ExtRequestPrebidSChainSChainNode
+	if publisherSChain != nil {
+		isComplete = publisherSChain.Complete
+		nodes = publisherSChain.Nodes
+	}
+
+	nodes = append(nodes, &node)
+
+	return openrtb_ext.ExtRequestPrebidSChainSChain{
+		Ver:      "1.0",
+		Complete: isComplete,
+		Nodes:    nodes,
+	}
+}
+
+// GetPublisherSChain25 Get the SChain from the 2.5 oRTB spec
+func GetPublisherSChain25(source *openrtb2.Source) *openrtb_ext.ExtRequestPrebidSChainSChain {
+	if source == nil {
+		return nil
+	}
+
+	var sourceExt openrtb_ext.SourceExt
+	if err := json.Unmarshal(source.Ext, &sourceExt); err != nil {
+		return nil
+	}
+
+	return &sourceExt.SChain
+}
+
+func MakeSChainNode(publisherId string, requestId string) openrtb_ext.ExtRequestPrebidSChainSChainNode {
+	return openrtb_ext.ExtRequestPrebidSChainSChainNode{
+		ASI: jwplayerDomain,
+		SID: publisherId,
+		RID: requestId,
+		HP:  1,
+	}
+}

--- a/adapters/jwplayer/ortbHelpers.go
+++ b/adapters/jwplayer/ortbHelpers.go
@@ -116,6 +116,10 @@ func GetPublisherSChain25(source *openrtb2.Source) *openrtb_ext.ExtRequestPrebid
 		return nil
 	}
 
+	if sourceExt.SChain.Nodes == nil {
+		return nil
+	}
+
 	return &sourceExt.SChain
 }
 

--- a/adapters/jwplayer/ortbHelpers_test.go
+++ b/adapters/jwplayer/ortbHelpers_test.go
@@ -1,0 +1,135 @@
+package jwplayer
+
+import (
+	"encoding/json"
+	"github.com/mxmCherry/openrtb/v15/openrtb2"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestParseBidderParams(t *testing.T) {
+	params, err := ParseBidderParams(openrtb2.Imp{
+		Ext: json.RawMessage(`{"bidder":{"placementId": "1"}}`),
+	})
+	assert.Empty(t, err)
+	assert.Equal(t, "1", params.PlacementId)
+
+	params, err = ParseBidderParams(openrtb2.Imp{
+		Ext: json.RawMessage(`{"else":{"placementId": "1"}}`),
+	})
+	assert.NotNil(t, err)
+	assert.Empty(t, params)
+
+	params, err = ParseBidderParams(openrtb2.Imp{
+		Ext: json.RawMessage(`{"bidder":{"otherId": "1"}}`),
+	})
+	assert.NotNil(t, err)
+	assert.Empty(t, params)
+}
+
+func TestContentMetadataParseSuccess(t *testing.T) {
+	description := "Test Description"
+	descriptionExt, _ := json.Marshal(ContentExt{
+		Description: description,
+	})
+	content := openrtb2.Content{
+		URL:   "//test.medial.url/file.mp4",
+		Title: "Test title",
+		Ext:   descriptionExt,
+	}
+
+	metadata := ParseContentMetadata(content)
+	assert.Equal(t, content.URL, metadata.Url)
+	assert.Equal(t, content.Title, metadata.Title)
+	assert.Equal(t, description, metadata.Description)
+}
+
+func TestGetExistingJwpsegs(t *testing.T) {
+	externalSegments1 := []openrtb2.Segment{{Value: "sthg"}, {Value: "else"}}
+	externalData1 := openrtb2.Data{Name: "external", Segment: externalSegments1}
+
+	externalSegments2 := []openrtb2.Segment{{Value: "sthg2"}, {Value: "else2"}}
+	externalData2 := openrtb2.Data{Name: "external number 2", Segment: externalSegments2}
+
+	jwSegments := []openrtb2.Segment{{Value: "1"}, {Value: "2"}}
+	dataExt := DataExt{Segtax: 502}
+	ext, _ := json.Marshal(dataExt)
+	jwData := openrtb2.Data{Name: "jwplayer.com", Segment: jwSegments, Ext: ext}
+
+	externalSegments3 := []openrtb2.Segment{{Value: "3"}, {Value: "4"}}
+	dataWithoutSegtax := openrtb2.Data{Name: "jwplayer.com", Segment: externalSegments3}
+
+	externalSegments4 := []openrtb2.Segment{{Value: "5"}, {Value: "6"}}
+	dataWithWrongName := openrtb2.Data{Name: "other.com", Segment: externalSegments4, Ext: ext}
+
+	dataWithEmptySegments := openrtb2.Data{Name: "jwplayer.com", Ext: ext}
+
+	jwpsegs := GetExistingJwpsegs([]openrtb2.Data{externalData1, dataWithoutSegtax, dataWithWrongName, dataWithEmptySegments, jwData, externalData2})
+	expectedJwpsegs := []string{"1", "2"}
+
+	assert.Len(t, jwpsegs, len(expectedJwpsegs))
+	assert.ElementsMatch(t, jwpsegs, expectedJwpsegs)
+}
+
+func TestHasJwpsegs(t *testing.T) {
+	segments := []openrtb2.Segment{{
+		Value: "88888888",
+	}}
+	jwDatumExt, _ := json.Marshal(DataExt{Segtax: jwplayerSegtax})
+	datum := openrtb2.Data{
+		Name:    "jwplayer.com",
+		Segment: segments,
+		Ext:     jwDatumExt,
+	}
+
+	assert.True(t, HasJwpsegs(datum))
+
+	datum.Name = "other"
+	assert.False(t, HasJwpsegs(datum))
+
+	datum.Name = "jwplayer.com"
+	datum.Ext, _ = json.Marshal(ContentExt{Description: "descr"})
+	assert.False(t, HasJwpsegs(datum))
+
+	datum.Ext = jwDatumExt
+	datum.Segment = []openrtb2.Segment{}
+	assert.False(t, HasJwpsegs(datum))
+}
+
+func TestParseJwpsegs(t *testing.T) {
+	var emptySegments []openrtb2.Segment
+	emptyJwpsegs := ParseJwpsegs(emptySegments)
+	assert.Empty(t, emptyJwpsegs)
+
+	segments := []openrtb2.Segment{{Value: "1"}, {Value: "2"}, {Value: "3"}}
+	jwpsegs := ParseJwpsegs(segments)
+	expectedJwpsegs := []string{"1", "2", "3"}
+	assert.Len(t, jwpsegs, len(segments))
+	assert.ElementsMatch(t, expectedJwpsegs, jwpsegs)
+}
+
+func TestMakeOrtbDatum(t *testing.T) {
+	jwpsegs := []string{"1", "2", "3"}
+	datum := MakeOrtbDatum(jwpsegs)
+
+	assert.Equal(t, datum.Name, "jwplayer.com")
+
+	var dataExt DataExt
+	json.Unmarshal(datum.Ext, &dataExt)
+	assert.Equal(t, dataExt.Segtax, 502)
+
+	expectedSegments := []openrtb2.Segment{{Value: "1"}, {Value: "2"}, {Value: "3"}}
+	assert.Len(t, datum.Segment, len(expectedSegments))
+	assert.ElementsMatch(t, datum.Segment, expectedSegments)
+}
+
+func TestMakeOrtbSegments(t *testing.T) {
+	var emptyJwpsegs []string
+	assert.Empty(t, MakeOrtbSegments(emptyJwpsegs))
+
+	jwpsegs := []string{"1", "2", "3"}
+	segments := MakeOrtbSegments(jwpsegs)
+	expectedSegments := []openrtb2.Segment{{Value: "1"}, {Value: "2"}, {Value: "3"}}
+	assert.Len(t, segments, len(expectedSegments))
+	assert.ElementsMatch(t, segments, expectedSegments)
+}

--- a/adapters/jwplayer/ortbHelpers_test.go
+++ b/adapters/jwplayer/ortbHelpers_test.go
@@ -39,9 +39,14 @@ func TestContentMetadataParseSuccess(t *testing.T) {
 	}
 
 	metadata := ParseContentMetadata(content)
-	assert.Equal(t, content.URL, metadata.Url)
-	assert.Equal(t, content.Title, metadata.Title)
-	assert.Equal(t, description, metadata.Description)
+
+	expectedMetadata := ContentMetadata{
+		Url:         "//test.medial.url/file.mp4",
+		Title:       "Test title",
+		Description: "Test Description",
+	}
+
+	assert.Equal(t, expectedMetadata, metadata)
 }
 
 func TestGetExistingJwpsegs(t *testing.T) {
@@ -112,15 +117,13 @@ func TestMakeOrtbDatum(t *testing.T) {
 	jwpsegs := []string{"1", "2", "3"}
 	datum := MakeOrtbDatum(jwpsegs)
 
-	assert.Equal(t, datum.Name, "jwplayer.com")
+	expectedDatum := openrtb2.Data{
+		Name:    "jwplayer.com",
+		Segment: []openrtb2.Segment{{Value: "1"}, {Value: "2"}, {Value: "3"}},
+		Ext:     json.RawMessage(`{"segtax":502}`),
+	}
 
-	var dataExt DataExt
-	json.Unmarshal(datum.Ext, &dataExt)
-	assert.Equal(t, dataExt.Segtax, 502)
-
-	expectedSegments := []openrtb2.Segment{{Value: "1"}, {Value: "2"}, {Value: "3"}}
-	assert.Len(t, datum.Segment, len(expectedSegments))
-	assert.ElementsMatch(t, datum.Segment, expectedSegments)
+	assert.Equal(t, expectedDatum, datum)
 }
 
 func TestMakeOrtbSegments(t *testing.T) {

--- a/adapters/jwplayer/params_test.go
+++ b/adapters/jwplayer/params_test.go
@@ -41,7 +41,6 @@ func getValidator(t *testing.T) openrtb_ext.BidderParamValidator {
 
 var validParams = []string{
 	`{"placementId": "123"}`,
-	`{"placementId": "123", "publisherId": "abc"}`,
 }
 
 var invalidParams = []string{

--- a/adapters/jwplayer/rtd.go
+++ b/adapters/jwplayer/rtd.go
@@ -1,0 +1,7 @@
+package jwplayer
+
+import "github.com/mxmCherry/openrtb/v15/openrtb2"
+
+type RTDAdapter interface {
+	EnrichRequest(request *openrtb2.BidRequest, siteId string) EnrichmentFailed
+}

--- a/adapters/jwplayer/utils.go
+++ b/adapters/jwplayer/utils.go
@@ -200,7 +200,7 @@ type requestExt struct {
 
 func MakeSChain(request *openrtb2.BidRequest, publisherId string) openrtb_ext.ExtRequestPrebidSChainSChain {
 	node := MakeSChainNode(publisherId, request.ID)
-	pub25SChain := GetPublisherSChain25(*request.Source)
+	pub25SChain := GetPublisherSChain25(request.Source)
 	isComplete := 1
 	var nodes []*openrtb_ext.ExtRequestPrebidSChainSChainNode
 	if pub25SChain != nil {
@@ -218,7 +218,11 @@ func MakeSChain(request *openrtb2.BidRequest, publisherId string) openrtb_ext.Ex
 }
 
 // GetPublisherSChain25 Get the SChain from the 2.5 oRTB spec
-func GetPublisherSChain25(source openrtb2.Source) *openrtb_ext.ExtRequestPrebidSChainSChain {
+func GetPublisherSChain25(source *openrtb2.Source) *openrtb_ext.ExtRequestPrebidSChainSChain {
+	if source == nil {
+		return nil
+	}
+
 	var sourceExt openrtb_ext.SourceExt
 	if err := json.Unmarshal(source.Ext, &sourceExt); err != nil {
 		return nil

--- a/adapters/jwplayer/utils.go
+++ b/adapters/jwplayer/utils.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"github.com/mxmCherry/openrtb/v15/openrtb2"
 	"github.com/prebid/prebid-server/adapters"
+	"github.com/prebid/prebid-server/errortypes"
 	"github.com/prebid/prebid-server/macros"
 	"github.com/prebid/prebid-server/openrtb_ext"
 	"net/url"
@@ -31,12 +32,18 @@ func ParseBidderParams(imp openrtb2.Imp) (*openrtb_ext.ImpExtJWPlayer, error) {
 		return nil, err
 	}
 
-	var params openrtb_ext.ImpExtJWPlayer
+	var params *openrtb_ext.ImpExtJWPlayer
 	if err := json.Unmarshal(impExt.Bidder, &params); err != nil {
 		return nil, err
 	}
 
-	return &params, nil
+	if params.PlacementId == "" {
+		return nil, &errortypes.BadInput{
+			Message: "Empty ext.prebid.bidder.jwplayer.placementId",
+		}
+	}
+
+	return params, nil
 }
 
 // copied from appnexus.go appnexusImpExtAppnexus

--- a/adapters/jwplayer/utils.go
+++ b/adapters/jwplayer/utils.go
@@ -54,15 +54,6 @@ func GetAppnexusExt(placementId string) json.RawMessage {
 	return jsonExt
 }
 
-func ParsePublisherParams(publisher openrtb2.Publisher) *jwplayerPublisher {
-	var pubExt publisherExt
-	if err := json.Unmarshal(publisher.Ext, &pubExt); err != nil {
-		return nil
-	}
-
-	return &pubExt.JWPlayer
-}
-
 func ParseContentMetadata(content openrtb2.Content) ContentMetadata {
 	metadata := ContentMetadata{
 		Url:   content.URL,

--- a/adapters/jwplayer/utils.go
+++ b/adapters/jwplayer/utils.go
@@ -1,84 +1,12 @@
 package jwplayer
 
 import (
-	"encoding/json"
 	"github.com/mxmCherry/openrtb/v15/openrtb2"
-	"github.com/prebid/prebid-server/adapters"
-	"github.com/prebid/prebid-server/errortypes"
-	"github.com/prebid/prebid-server/macros"
-	"github.com/prebid/prebid-server/openrtb_ext"
 	"net/url"
-	"text/template"
 )
-
-func ParseExtraInfo(v string) ExtraInfo {
-	var extraInfo ExtraInfo
-	if err := json.Unmarshal([]byte(v), &extraInfo); err != nil {
-		extraInfo = ExtraInfo{}
-	}
-
-	if extraInfo.TargetingEndpoint == "" {
-		extraInfo.TargetingEndpoint = "https://content-targeting-api.longtailvideo.com/property/{{.SiteId}}/content_segments?content_url=%{{.MediaUrl}}&title={{.Title}}&description={{.Description}}"
-	}
-
-	return extraInfo
-}
-
-func ParseBidderParams(imp openrtb2.Imp) (*openrtb_ext.ImpExtJWPlayer, error) {
-	var impExt adapters.ExtImpBidder
-	if err := json.Unmarshal(imp.Ext, &impExt); err != nil {
-		return nil, err
-	}
-
-	var params *openrtb_ext.ImpExtJWPlayer
-	if err := json.Unmarshal(impExt.Bidder, &params); err != nil {
-		return nil, err
-	}
-
-	if params.PlacementId == "" {
-		return nil, &errortypes.BadInput{
-			Message: "Empty ext.prebid.bidder.jwplayer.placementId",
-		}
-	}
-
-	return params, nil
-}
 
 func IsInstream(placementType openrtb2.VideoPlacementType) bool {
 	return placementType == openrtb2.VideoPlacementTypeInStream
-}
-
-func ParseContentMetadata(content openrtb2.Content) ContentMetadata {
-	metadata := ContentMetadata{
-		Url:   content.URL,
-		Title: content.Title,
-	}
-
-	contentExt := ContentExt{}
-	if error := json.Unmarshal(content.Ext, &contentExt); error == nil {
-		metadata.Description = contentExt.Description
-	}
-
-	return metadata
-}
-
-func GetExistingJwpsegs(data []openrtb2.Data) []string {
-	for _, datum := range data {
-		if HasJwpsegs(datum) {
-			return ParseJwpsegs(datum.Segment)
-		}
-	}
-
-	return nil
-}
-
-func HasJwpsegs(datum openrtb2.Data) bool {
-	dataExt := DataExt{}
-	if error := json.Unmarshal(datum.Ext, &dataExt); error != nil {
-		return false
-	}
-
-	return datum.Name == jwplayerDomain && dataExt.Segtax == jwplayerSegtax && len(datum.Segment) > 0
 }
 
 func IsValidMediaUrl(rawUrl string) bool {
@@ -100,112 +28,10 @@ func IsValidMediaUrl(rawUrl string) bool {
 	return !isRelativePath
 }
 
-type EndpointTemplateParams struct {
-	SiteId      string
-	MediaUrl    string
-	Title       string
-	Description string
-}
-
-func BuildTargetingEndpoint(endpointTemplate *template.Template, siteId string, contentMetadata ContentMetadata) string {
-	if endpointTemplate == nil {
-		return ""
-	}
-
-	mediaUrl := url.QueryEscape(contentMetadata.Url)
-	title := url.QueryEscape(contentMetadata.Title)
-	description := url.QueryEscape(contentMetadata.Description)
-
-	endpointParams := EndpointTemplateParams{
-		SiteId:      siteId,
-		MediaUrl:    mediaUrl,
-		Title:       title,
-		Description: description,
-	}
-
-	reqUrl, macroResolveErr := macros.ResolveMacros(endpointTemplate, endpointParams)
-	if macroResolveErr != nil {
-		return ""
-	}
-
-	return reqUrl
-}
-
-func ParseJwpsegs(segments []openrtb2.Segment) []string {
-	segmentToJwpseg := func(segment openrtb2.Segment) string { return segment.Value }
-	jwpsegs := Map(segments, segmentToJwpseg)
-	return jwpsegs
-}
-
-func GetAllJwpsegs(targeting TargetingData) []string {
-	return append(targeting.BaseSegments, targeting.TargetingProfiles...)
-}
-
-func MakeOrtbDatum(jwpsegs []string) (contentData openrtb2.Data) {
-	contentData.Name = jwplayerDomain
-	contentData.Segment = MakeOrtbSegments(jwpsegs)
-	dataExt := DataExt{
-		Segtax: jwplayerSegtax,
-	}
-	contentData.Ext, _ = json.Marshal(dataExt)
-	return contentData
-}
-
-func MakeOrtbSegments(jwpsegs []string) []openrtb2.Segment {
-	jwpsegToSegment := func(jwpseg string) openrtb2.Segment { return openrtb2.Segment{Value: jwpseg} }
-	segments := Map(jwpsegs, jwpsegToSegment)
-	return segments
-}
-
 func Map[T any, M any](inputs []T, f func(T) M) []M {
 	outputs := make([]M, len(inputs))
 	for i, element := range inputs {
 		outputs[i] = f(element)
 	}
 	return outputs
-}
-
-type requestExt struct {
-	SChain openrtb_ext.ExtRequestPrebidSChainSChain `json:"schain"`
-}
-
-func MakeSChain(publisherId string, requestId string, publisherSChain *openrtb_ext.ExtRequestPrebidSChainSChain) openrtb_ext.ExtRequestPrebidSChainSChain {
-	node := MakeSChainNode(publisherId, requestId)
-	isComplete := 1
-	var nodes []*openrtb_ext.ExtRequestPrebidSChainSChainNode
-	if publisherSChain != nil {
-		isComplete = publisherSChain.Complete
-		nodes = publisherSChain.Nodes
-	}
-
-	nodes = append(nodes, &node)
-
-	return openrtb_ext.ExtRequestPrebidSChainSChain{
-		Ver:      "1.0",
-		Complete: isComplete,
-		Nodes:    nodes,
-	}
-}
-
-// GetPublisherSChain25 Get the SChain from the 2.5 oRTB spec
-func GetPublisherSChain25(source *openrtb2.Source) *openrtb_ext.ExtRequestPrebidSChainSChain {
-	if source == nil {
-		return nil
-	}
-
-	var sourceExt openrtb_ext.SourceExt
-	if err := json.Unmarshal(source.Ext, &sourceExt); err != nil {
-		return nil
-	}
-
-	return &sourceExt.SChain
-}
-
-func MakeSChainNode(publisherId string, requestId string) openrtb_ext.ExtRequestPrebidSChainSChainNode {
-	return openrtb_ext.ExtRequestPrebidSChainSChainNode{
-		ASI: jwplayerDomain,
-		SID: publisherId,
-		RID: requestId,
-		HP:  1,
-	}
 }

--- a/adapters/jwplayer/utils.go
+++ b/adapters/jwplayer/utils.go
@@ -204,14 +204,13 @@ type requestExt struct {
 	SChain openrtb_ext.ExtRequestPrebidSChainSChain `json:"schain"`
 }
 
-func MakeSChain(request *openrtb2.BidRequest, publisherId string) openrtb_ext.ExtRequestPrebidSChainSChain {
-	node := MakeSChainNode(publisherId, request.ID)
-	pub25SChain := GetPublisherSChain25(request.Source)
+func MakeSChain(publisherId string, requestId string, publisherSChain *openrtb_ext.ExtRequestPrebidSChainSChain) openrtb_ext.ExtRequestPrebidSChainSChain {
+	node := MakeSChainNode(publisherId, requestId)
 	isComplete := 1
 	var nodes []*openrtb_ext.ExtRequestPrebidSChainSChainNode
-	if pub25SChain != nil {
-		isComplete = pub25SChain.Complete
-		nodes = pub25SChain.Nodes
+	if publisherSChain != nil {
+		isComplete = publisherSChain.Complete
+		nodes = publisherSChain.Nodes
 	}
 
 	nodes = append(nodes, &node)

--- a/adapters/jwplayer/utils.go
+++ b/adapters/jwplayer/utils.go
@@ -47,23 +47,23 @@ func ParseBidderParams(imp openrtb2.Imp) (*openrtb_ext.ImpExtJWPlayer, error) {
 }
 
 // copied from appnexus.go appnexusImpExtAppnexus
-type appnexusImpExtParams struct {
+type xandrImpExtParams struct {
 	PlacementID int `json:"placement_id,omitempty"`
 }
 
 // copied from appnexus.go appnexusImpExt
-type appnexusImpExt struct {
-	Appnexus appnexusImpExtParams `json:"appnexus"`
+type xandrImpExt struct {
+	Appnexus xandrImpExtParams `json:"appnexus"`
 }
 
-func GetAppnexusExt(placementId string) json.RawMessage {
+func GetXandrImpExt(placementId string) json.RawMessage {
 	id, conversionError := strconv.Atoi(placementId)
 	if conversionError != nil {
 		return nil
 	}
 
-	appnexusExt := &appnexusImpExt{
-		Appnexus: appnexusImpExtParams{
+	appnexusExt := &xandrImpExt{
+		Appnexus: xandrImpExtParams{
 			PlacementID: id,
 		},
 	}
@@ -99,7 +99,7 @@ func SetXandrVideoExt(video *openrtb2.Video) {
 	if context == Unknown {
 		return
 	}
-	
+
 	videoExt := xandrVideoExt{
 		Appnexus: xandrVideoExtParams{
 			Context: context,

--- a/adapters/jwplayer/utils.go
+++ b/adapters/jwplayer/utils.go
@@ -44,8 +44,8 @@ func ParseBidderParams(imp openrtb2.Imp) (*openrtb_ext.ImpExtJWPlayer, error) {
 	return params, nil
 }
 
-func IsOutstream(placementType openrtb2.VideoPlacementType) bool {
-	return placementType > 1
+func IsInstream(placementType openrtb2.VideoPlacementType) bool {
+	return placementType == openrtb2.VideoPlacementTypeInStream
 }
 
 func ParseContentMetadata(content openrtb2.Content) ContentMetadata {

--- a/adapters/jwplayer/utils.go
+++ b/adapters/jwplayer/utils.go
@@ -3,6 +3,7 @@ package jwplayer
 import (
 	"encoding/json"
 	"github.com/mxmCherry/openrtb/v15/openrtb2"
+	"github.com/prebid/prebid-server/adapters"
 	"github.com/prebid/prebid-server/macros"
 	"github.com/prebid/prebid-server/openrtb_ext"
 	"net/url"
@@ -22,6 +23,20 @@ func ParseExtraInfo(v string) ExtraInfo {
 	}
 
 	return extraInfo
+}
+
+func ParseBidderParams(imp openrtb2.Imp) (*openrtb_ext.ImpExtJWPlayer, error) {
+	var impExt adapters.ExtImpBidder
+	if err := json.Unmarshal(imp.Ext, &impExt); err != nil {
+		return nil, err
+	}
+
+	var params openrtb_ext.ImpExtJWPlayer
+	if err := json.Unmarshal(impExt.Bidder, &params); err != nil {
+		return nil, err
+	}
+
+	return &params, nil
 }
 
 // copied from appnexus.go appnexusImpExtAppnexus

--- a/adapters/jwplayer/utils_test.go
+++ b/adapters/jwplayer/utils_test.go
@@ -40,14 +40,14 @@ func TestParseBidderParams(t *testing.T) {
 	assert.Empty(t, params)
 }
 
-func TestGetAppnexusExt(t *testing.T) {
-	appnexusExt := GetAppnexusExt("1234")
-	var appnexusImp appnexusImpExt
+func TestGetXandrImpExt(t *testing.T) {
+	appnexusExt := GetXandrImpExt("1234")
+	var appnexusImp xandrImpExt
 	json.Unmarshal(appnexusExt, &appnexusImp)
 	assert.Equal(t, 1234, appnexusImp.Appnexus.PlacementID)
 
-	var badAppnexusImp appnexusImpExt
-	badAppnexusExt := GetAppnexusExt("-/")
+	var badAppnexusImp xandrImpExt
+	badAppnexusExt := GetXandrImpExt("-/")
 	json.Unmarshal(badAppnexusExt, &badAppnexusImp)
 	assert.Empty(t, badAppnexusImp)
 }

--- a/adapters/jwplayer/utils_test.go
+++ b/adapters/jwplayer/utils_test.go
@@ -1,44 +1,10 @@
 package jwplayer
 
 import (
-	"encoding/json"
 	"github.com/mxmCherry/openrtb/v15/openrtb2"
 	"github.com/stretchr/testify/assert"
 	"testing"
-	"text/template"
 )
-
-func TestParseExtraInfo(t *testing.T) {
-	extraInfo := ParseExtraInfo("{\"targeting_endpoint\": \"targetingUrl\"}")
-	assert.Equal(t, "targetingUrl", extraInfo.TargetingEndpoint)
-
-	defaultTargetingUrl := "https://content-targeting-api.longtailvideo.com/property/{{.SiteId}}/content_segments?content_url=%{{.MediaUrl}}&title={{.Title}}&description={{.Description}}"
-	extraInfo = ParseExtraInfo("{/")
-	assert.Equal(t, defaultTargetingUrl, extraInfo.TargetingEndpoint)
-
-	extraInfo = ParseExtraInfo("{}")
-	assert.Equal(t, defaultTargetingUrl, extraInfo.TargetingEndpoint)
-}
-
-func TestParseBidderParams(t *testing.T) {
-	params, err := ParseBidderParams(openrtb2.Imp{
-		Ext: json.RawMessage(`{"bidder":{"placementId": "1"}}`),
-	})
-	assert.Empty(t, err)
-	assert.Equal(t, "1", params.PlacementId)
-
-	params, err = ParseBidderParams(openrtb2.Imp{
-		Ext: json.RawMessage(`{"else":{"placementId": "1"}}`),
-	})
-	assert.NotNil(t, err)
-	assert.Empty(t, params)
-
-	params, err = ParseBidderParams(openrtb2.Imp{
-		Ext: json.RawMessage(`{"bidder":{"otherId": "1"}}`),
-	})
-	assert.NotNil(t, err)
-	assert.Empty(t, params)
-}
 
 func TestIsInstream(t *testing.T) {
 	assert.True(t, IsInstream(openrtb2.VideoPlacementTypeInStream))
@@ -47,75 +13,6 @@ func TestIsInstream(t *testing.T) {
 	assert.False(t, IsInstream(openrtb2.VideoPlacementTypeInArticle))
 	assert.False(t, IsInstream(openrtb2.VideoPlacementTypeInFeed))
 	assert.False(t, IsInstream(openrtb2.VideoPlacementTypeInterstitialSliderFloating))
-}
-
-func TestContentMetadataParseSuccess(t *testing.T) {
-	description := "Test Description"
-	descriptionExt, _ := json.Marshal(ContentExt{
-		Description: description,
-	})
-	content := openrtb2.Content{
-		URL:   "//test.medial.url/file.mp4",
-		Title: "Test title",
-		Ext:   descriptionExt,
-	}
-
-	metadata := ParseContentMetadata(content)
-	assert.Equal(t, content.URL, metadata.Url)
-	assert.Equal(t, content.Title, metadata.Title)
-	assert.Equal(t, description, metadata.Description)
-}
-
-func TestGetExistingJwpsegs(t *testing.T) {
-	externalSegments1 := []openrtb2.Segment{{Value: "sthg"}, {Value: "else"}}
-	externalData1 := openrtb2.Data{Name: "external", Segment: externalSegments1}
-
-	externalSegments2 := []openrtb2.Segment{{Value: "sthg2"}, {Value: "else2"}}
-	externalData2 := openrtb2.Data{Name: "external number 2", Segment: externalSegments2}
-
-	jwSegments := []openrtb2.Segment{{Value: "1"}, {Value: "2"}}
-	dataExt := DataExt{Segtax: 502}
-	ext, _ := json.Marshal(dataExt)
-	jwData := openrtb2.Data{Name: "jwplayer.com", Segment: jwSegments, Ext: ext}
-
-	externalSegments3 := []openrtb2.Segment{{Value: "3"}, {Value: "4"}}
-	dataWithoutSegtax := openrtb2.Data{Name: "jwplayer.com", Segment: externalSegments3}
-
-	externalSegments4 := []openrtb2.Segment{{Value: "5"}, {Value: "6"}}
-	dataWithWrongName := openrtb2.Data{Name: "other.com", Segment: externalSegments4, Ext: ext}
-
-	dataWithEmptySegments := openrtb2.Data{Name: "jwplayer.com", Ext: ext}
-
-	jwpsegs := GetExistingJwpsegs([]openrtb2.Data{externalData1, dataWithoutSegtax, dataWithWrongName, dataWithEmptySegments, jwData, externalData2})
-	expectedJwpsegs := []string{"1", "2"}
-
-	assert.Len(t, jwpsegs, len(expectedJwpsegs))
-	assert.ElementsMatch(t, jwpsegs, expectedJwpsegs)
-}
-
-func TestHasJwpsegs(t *testing.T) {
-	segments := []openrtb2.Segment{{
-		Value: "88888888",
-	}}
-	jwDatumExt, _ := json.Marshal(DataExt{Segtax: jwplayerSegtax})
-	datum := openrtb2.Data{
-		Name:    "jwplayer.com",
-		Segment: segments,
-		Ext:     jwDatumExt,
-	}
-
-	assert.True(t, HasJwpsegs(datum))
-
-	datum.Name = "other"
-	assert.False(t, HasJwpsegs(datum))
-
-	datum.Name = "jwplayer.com"
-	datum.Ext, _ = json.Marshal(ContentExt{Description: "descr"})
-	assert.False(t, HasJwpsegs(datum))
-
-	datum.Ext = jwDatumExt
-	datum.Segment = []openrtb2.Segment{}
-	assert.False(t, HasJwpsegs(datum))
 }
 
 func TestIsValidMediaUrl(t *testing.T) {
@@ -132,93 +29,4 @@ func TestIsValidMediaUrl(t *testing.T) {
 	assert.True(t, IsValidMediaUrl("http://hello.com/media.mp4"))
 	assert.True(t, IsValidMediaUrl("https://hello.com/media.mp4"))
 	assert.True(t, IsValidMediaUrl("https://hello.com/media.mp4?additional=sthg"))
-}
-
-func TestBuildTargetingEndpoint(t *testing.T) {
-	badEndpoint := BuildTargetingEndpoint(nil, "", ContentMetadata{})
-	assert.Empty(t, badEndpoint)
-
-	correctTemplate, _ := template.New("targetingEndpointTemplate").Parse("domain.com/{{.SiteId}}/{{.MediaUrl}}/{{.Title}}/{{.Description}}")
-	metadata1 := ContentMetadata{
-		Url:         "testUrl",
-		Title:       "testTitle",
-		Description: "testDescription",
-	}
-	correctEndpoint := BuildTargetingEndpoint(correctTemplate, "testSideId", metadata1)
-	assert.Equal(t, "domain.com/testSideId/testUrl/testTitle/testDescription", correctEndpoint)
-
-	missingTitleTemplate, _ := template.New("targetingEndpointTemplate").Parse("domain.com/{{.SiteId}}/{{.MediaUrl}}/{{.Description}}")
-	metadata2 := ContentMetadata{
-		Url:   "testUrl",
-		Title: "testTitle",
-	}
-	missingTitleEndpoint := BuildTargetingEndpoint(missingTitleTemplate, "testSideId", metadata2)
-	assert.Equal(t, "domain.com/testSideId/testUrl/", missingTitleEndpoint)
-
-	missingSiteIdTemplate, _ := template.New("targetingEndpointTemplate").Parse("domain.com/{{.MediaUrl}}/{{.Title}}/{{.Description}}")
-	metadata3 := ContentMetadata{
-		Title:       "testTitle",
-		Description: "testDescription",
-	}
-	missingSiteIdEndpoint := BuildTargetingEndpoint(missingSiteIdTemplate, "testSideId", metadata3)
-	assert.Equal(t, "domain.com//testTitle/testDescription", missingSiteIdEndpoint)
-
-	extraParamTemplate, _ := template.New("targetingEndpointTemplate").Parse("domain.com/{{.SiteId}}/{{.Sthg}}/{{.MediaUrl}}/{{.Title}}/{{.Description}}")
-	metadata4 := ContentMetadata{
-		Url:         "testUrl",
-		Description: "testDescription",
-	}
-	extraParamEndpoint := BuildTargetingEndpoint(extraParamTemplate, "testSideId", metadata4)
-	assert.Empty(t, extraParamEndpoint)
-}
-
-func TestParseJwpsegs(t *testing.T) {
-	var emptySegments []openrtb2.Segment
-	emptyJwpsegs := ParseJwpsegs(emptySegments)
-	assert.Empty(t, emptyJwpsegs)
-
-	segments := []openrtb2.Segment{{Value: "1"}, {Value: "2"}, {Value: "3"}}
-	jwpsegs := ParseJwpsegs(segments)
-	expectedJwpsegs := []string{"1", "2", "3"}
-	assert.Len(t, jwpsegs, len(segments))
-	assert.ElementsMatch(t, expectedJwpsegs, jwpsegs)
-}
-
-func TestGetAllJwpsegs(t *testing.T) {
-	targetingData := TargetingData{
-		BaseSegments:      []string{"1", "2", "3"},
-		TargetingProfiles: []string{"4", "5"},
-	}
-
-	jwpsegs := GetAllJwpsegs(targetingData)
-	expectedJwpsegs := []string{"1", "2", "3", "4", "5"}
-
-	assert.Len(t, jwpsegs, len(expectedJwpsegs))
-	assert.ElementsMatch(t, jwpsegs, expectedJwpsegs)
-}
-
-func TestMakeOrtbDatum(t *testing.T) {
-	jwpsegs := []string{"1", "2", "3"}
-	datum := MakeOrtbDatum(jwpsegs)
-
-	assert.Equal(t, datum.Name, "jwplayer.com")
-
-	var dataExt DataExt
-	json.Unmarshal(datum.Ext, &dataExt)
-	assert.Equal(t, dataExt.Segtax, 502)
-
-	expectedSegments := []openrtb2.Segment{{Value: "1"}, {Value: "2"}, {Value: "3"}}
-	assert.Len(t, datum.Segment, len(expectedSegments))
-	assert.ElementsMatch(t, datum.Segment, expectedSegments)
-}
-
-func TestMakeOrtbSegments(t *testing.T) {
-	var emptyJwpsegs []string
-	assert.Empty(t, MakeOrtbSegments(emptyJwpsegs))
-
-	jwpsegs := []string{"1", "2", "3"}
-	segments := MakeOrtbSegments(jwpsegs)
-	expectedSegments := []openrtb2.Segment{{Value: "1"}, {Value: "2"}, {Value: "3"}}
-	assert.Len(t, segments, len(expectedSegments))
-	assert.ElementsMatch(t, segments, expectedSegments)
 }

--- a/adapters/jwplayer/utils_test.go
+++ b/adapters/jwplayer/utils_test.go
@@ -40,13 +40,13 @@ func TestParseBidderParams(t *testing.T) {
 	assert.Empty(t, params)
 }
 
-func TestIsOutstream(t *testing.T) {
-	assert.False(t, IsOutstream(openrtb2.VideoPlacementTypeInStream))
+func TestIsInstream(t *testing.T) {
+	assert.True(t, IsInstream(openrtb2.VideoPlacementTypeInStream))
 
-	assert.True(t, IsOutstream(openrtb2.VideoPlacementTypeInBanner))
-	assert.True(t, IsOutstream(openrtb2.VideoPlacementTypeInArticle))
-	assert.True(t, IsOutstream(openrtb2.VideoPlacementTypeInFeed))
-	assert.True(t, IsOutstream(openrtb2.VideoPlacementTypeInterstitialSliderFloating))
+	assert.False(t, IsInstream(openrtb2.VideoPlacementTypeInBanner))
+	assert.False(t, IsInstream(openrtb2.VideoPlacementTypeInArticle))
+	assert.False(t, IsInstream(openrtb2.VideoPlacementTypeInFeed))
+	assert.False(t, IsInstream(openrtb2.VideoPlacementTypeInterstitialSliderFloating))
 }
 
 func TestContentMetadataParseSuccess(t *testing.T) {

--- a/adapters/jwplayer/utils_test.go
+++ b/adapters/jwplayer/utils_test.go
@@ -20,6 +20,25 @@ func TestParseExtraInfo(t *testing.T) {
 	assert.Equal(t, defaultTargetingUrl, extraInfo.TargetingEndpoint)
 }
 
+func TestParseBidderParams(t *testing.T) {
+	params, err := ParseBidderParams(openrtb2.Imp{
+		Ext: json.RawMessage(`{"bidder":{"placementId": "1"}}`),
+	})
+	assert.Empty(t, err)
+	assert.Equal(t, "1", params.PlacementId)
+
+	params, err = ParseBidderParams(openrtb2.Imp{
+		Ext: json.RawMessage(`{"else":{"placementId": "1"}}`),
+	})
+	assert.NotNil(t, err)
+	assert.Empty(t, params)
+
+	params, err = ParseBidderParams(openrtb2.Imp{
+		Ext: json.RawMessage(`{"bidder":{"otherId": "1"}}`),
+	})
+	assert.Empty(t, params.PlacementId)
+}
+
 func TestGetAppnexusExt(t *testing.T) {
 	appnexusExt := GetAppnexusExt("1234")
 	var appnexusImp appnexusImpExt

--- a/adapters/jwplayer/utils_test.go
+++ b/adapters/jwplayer/utils_test.go
@@ -40,58 +40,6 @@ func TestParseBidderParams(t *testing.T) {
 	assert.Empty(t, params)
 }
 
-func TestGetXandrImpExt(t *testing.T) {
-	appnexusExt := GetXandrImpExt("1234")
-	var appnexusImp xandrImpExt
-	json.Unmarshal(appnexusExt, &appnexusImp)
-	assert.Equal(t, 1234, appnexusImp.Appnexus.PlacementID)
-
-	var badAppnexusImp xandrImpExt
-	badAppnexusExt := GetXandrImpExt("-/")
-	json.Unmarshal(badAppnexusExt, &badAppnexusImp)
-	assert.Empty(t, badAppnexusImp)
-}
-
-func TestSetXandrVideoExt(t *testing.T) {
-	video := &openrtb2.Video{}
-	SetXandrVideoExt(video)
-	assert.Empty(t, video.Ext)
-
-	video.Placement = openrtb2.VideoPlacementTypeInArticle
-	SetXandrVideoExt(video)
-	assert.NotNil(t, video.Ext)
-	var ext xandrVideoExt
-	json.Unmarshal(video.Ext, &ext)
-	assert.Equal(t, Outstream, ext.Appnexus.Context)
-
-	video.Ext = nil
-	video.Placement = openrtb2.VideoPlacementTypeInStream
-	video.StartDelay = openrtb2.StartDelayGenericPostRoll.Ptr()
-	SetXandrVideoExt(video)
-	assert.NotNil(t, video.Ext)
-	json.Unmarshal(video.Ext, &ext)
-	assert.Equal(t, PostRoll, ext.Appnexus.Context)
-}
-
-func TestGetXandrContext(t *testing.T) {
-	video := openrtb2.Video{}
-	assert.Equal(t, Unknown, GetXandrContext(video))
-
-	video.Placement = openrtb2.VideoPlacementTypeInBanner
-	video.StartDelay = openrtb2.StartDelayPreRoll.Ptr()
-	assert.Equal(t, Outstream, GetXandrContext(video))
-
-	video.Placement = openrtb2.VideoPlacementTypeInStream
-	assert.Equal(t, PreRoll, GetXandrContext(video))
-}
-
-func TestGetXandrContextFromStartdelay(t *testing.T) {
-	assert.Equal(t, PreRoll, GetXandrContextFromStartdelay(openrtb2.StartDelayPreRoll))
-	assert.Equal(t, MidRoll, GetXandrContextFromStartdelay(openrtb2.StartDelayGenericMidRoll))
-	assert.Equal(t, MidRoll, GetXandrContextFromStartdelay(openrtb2.StartDelay(5)))
-	assert.Equal(t, PostRoll, GetXandrContextFromStartdelay(openrtb2.StartDelayGenericPostRoll))
-}
-
 func TestIsOutstream(t *testing.T) {
 	assert.False(t, IsOutstream(openrtb2.VideoPlacementTypeInStream))
 
@@ -273,16 +221,4 @@ func TestMakeOrtbSegments(t *testing.T) {
 	expectedSegments := []openrtb2.Segment{{Value: "1"}, {Value: "2"}, {Value: "3"}}
 	assert.Len(t, segments, len(expectedSegments))
 	assert.ElementsMatch(t, segments, expectedSegments)
-}
-
-func TestWriteToXandrKeywords(t *testing.T) {
-	keyword := "key=value"
-	var jwpsegs []string
-	WriteToXandrKeywords(&keyword, jwpsegs)
-	assert.Equal(t, "key=value", keyword)
-
-	jwpsegs = append(jwpsegs, "80808080")
-	WriteToXandrKeywords(&keyword, jwpsegs)
-	assert.Equal(t, "key=value,jwpseg=80808080", keyword)
-
 }

--- a/adapters/jwplayer/utils_test.go
+++ b/adapters/jwplayer/utils_test.go
@@ -32,16 +32,6 @@ func TestGetAppnexusExt(t *testing.T) {
 	assert.Empty(t, badAppnexusImp)
 }
 
-func TestParsePublisherParams(t *testing.T) {
-	publisher := openrtb2.Publisher{
-		Ext: json.RawMessage(`{"otherBidder":{"placementId": "test_placement_id"}, "jwplayer":{"siteId": "testSideId", "publisherId": "testPublisherId"}}`),
-	}
-
-	jwpub := ParsePublisherParams(publisher)
-	assert.Equal(t, "testSideId", jwpub.SiteId)
-	assert.Equal(t, "testPublisherId", jwpub.PublisherId)
-}
-
 func TestContentMetadataParseSuccess(t *testing.T) {
 	description := "Test Description"
 	descriptionExt, _ := json.Marshal(ContentExt{

--- a/adapters/jwplayer/utils_test.go
+++ b/adapters/jwplayer/utils_test.go
@@ -36,6 +36,7 @@ func TestParseBidderParams(t *testing.T) {
 	params, err = ParseBidderParams(openrtb2.Imp{
 		Ext: json.RawMessage(`{"bidder":{"otherId": "1"}}`),
 	})
+	assert.NotNil(t, err)
 	assert.Empty(t, params)
 }
 

--- a/adapters/jwplayer/utils_test.go
+++ b/adapters/jwplayer/utils_test.go
@@ -36,7 +36,7 @@ func TestParseBidderParams(t *testing.T) {
 	params, err = ParseBidderParams(openrtb2.Imp{
 		Ext: json.RawMessage(`{"bidder":{"otherId": "1"}}`),
 	})
-	assert.Empty(t, params.PlacementId)
+	assert.Empty(t, params)
 }
 
 func TestGetAppnexusExt(t *testing.T) {

--- a/adapters/jwplayer/xandr.go
+++ b/adapters/jwplayer/xandr.go
@@ -71,6 +71,10 @@ func SetXandrVideoExt(video *openrtb2.Video) {
 }
 
 func GetXandrContext(video openrtb2.Video) xandrContext {
+	if video.Placement == 0 {
+		return Unknown
+	}
+
 	if IsInstream(video.Placement) == false {
 		return Outstream
 	}

--- a/adapters/jwplayer/xandr.go
+++ b/adapters/jwplayer/xandr.go
@@ -71,7 +71,7 @@ func SetXandrVideoExt(video *openrtb2.Video) {
 }
 
 func GetXandrContext(video openrtb2.Video) xandrContext {
-	if IsOutstream(video.Placement) == true {
+	if IsInstream(video.Placement) == false {
 		return Outstream
 	}
 

--- a/adapters/jwplayer/xandr.go
+++ b/adapters/jwplayer/xandr.go
@@ -1,0 +1,138 @@
+package jwplayer
+
+import (
+	"encoding/json"
+	"github.com/mxmCherry/openrtb/v15/openrtb2"
+	"github.com/prebid/prebid-server/openrtb_ext"
+	"strconv"
+	"strings"
+)
+
+// copied from appnexus.go appnexusImpExtAppnexus
+type xandrImpExtParams struct {
+	PlacementID int `json:"placement_id,omitempty"`
+}
+
+// copied from appnexus.go appnexusImpExt
+type xandrImpExt struct {
+	Appnexus xandrImpExtParams `json:"appnexus"`
+}
+
+func GetXandrImpExt(placementId string) json.RawMessage {
+	id, conversionError := strconv.Atoi(placementId)
+	if conversionError != nil {
+		return nil
+	}
+
+	appnexusExt := &xandrImpExt{
+		Appnexus: xandrImpExtParams{
+			PlacementID: id,
+		},
+	}
+
+	jsonExt, jsonError := json.Marshal(appnexusExt)
+	if jsonError != nil {
+		return nil
+	}
+
+	return jsonExt
+}
+
+type xandrVideoExt struct {
+	Appnexus xandrVideoExtParams `json:"appnexus"`
+}
+
+type xandrVideoExtParams struct {
+	Context xandrContext `json:"context,omitempty"`
+}
+
+type xandrContext int
+
+const (
+	Unknown   xandrContext = 0
+	PreRoll   xandrContext = 1
+	MidRoll   xandrContext = 2
+	PostRoll  xandrContext = 3
+	Outstream xandrContext = 4
+)
+
+func SetXandrVideoExt(video *openrtb2.Video) {
+	context := GetXandrContext(*video)
+	if context == Unknown {
+		return
+	}
+
+	videoExt := xandrVideoExt{
+		Appnexus: xandrVideoExtParams{
+			Context: context,
+		},
+	}
+	video.Ext, _ = json.Marshal(videoExt)
+}
+
+func GetXandrContext(video openrtb2.Video) xandrContext {
+	if IsOutstream(video.Placement) == true {
+		return Outstream
+	}
+
+	if video.StartDelay == nil {
+		return Unknown
+	}
+
+	return GetXandrContextFromStartdelay(*video.StartDelay)
+}
+
+func GetXandrContextFromStartdelay(startDelay openrtb2.StartDelay) xandrContext {
+	if startDelay > 0 {
+		return MidRoll // startdelay > 0 indicates ad position in seconds
+	}
+
+	switch startDelay {
+	case openrtb2.StartDelayPreRoll:
+		return PreRoll
+	case openrtb2.StartDelayGenericMidRoll:
+		return MidRoll
+	case openrtb2.StartDelayGenericPostRoll:
+		return PostRoll
+	}
+
+	return Unknown
+}
+
+func WriteToXandrKeywords(keywords *string, jwpsegs []string) {
+	if len(jwpsegs) == 0 {
+		return
+	}
+
+	if len(*keywords) > 0 {
+		*keywords += ","
+	}
+
+	jwpsegToKeyword := func(jwpseg string) string { return "jwpseg=" + jwpseg }
+	newKeywords := Map(jwpsegs, jwpsegToKeyword)
+	*keywords += strings.Join(newKeywords, ",")
+}
+
+func ConvertToXandrKeywords(jwpsegs []string) string {
+	if len(jwpsegs) == 0 {
+		return ""
+	}
+
+	keyword := "jwpseg="
+	// expected format: jwpseg=1,jwpseg=2,jwpseg=3
+	keyword += strings.Join(jwpsegs, ","+keyword)
+	return keyword
+}
+
+func GetXandrRequestExt(schain openrtb_ext.ExtRequestPrebidSChainSChain) json.RawMessage {
+	// Xandr expects the SChain to be in accordance with oRTB 2.4
+	// $.ext.schain
+	requestExtension := requestExt{
+		SChain: schain,
+	}
+	jsonExt, jsonError := json.Marshal(requestExtension)
+	if jsonError != nil {
+		return nil
+	}
+	return jsonExt
+}

--- a/adapters/jwplayer/xandr_test.go
+++ b/adapters/jwplayer/xandr_test.go
@@ -9,14 +9,8 @@ import (
 
 func TestGetXandrImpExt(t *testing.T) {
 	appnexusExt := GetXandrImpExt("1234")
-	var appnexusImp xandrImpExt
-	json.Unmarshal(appnexusExt, &appnexusImp)
-	assert.Equal(t, 1234, appnexusImp.Appnexus.PlacementID)
-
-	var badAppnexusImp xandrImpExt
-	badAppnexusExt := GetXandrImpExt("-/")
-	json.Unmarshal(badAppnexusExt, &badAppnexusImp)
-	assert.Empty(t, badAppnexusImp)
+	expectedJSON := json.RawMessage(`{"appnexus":{"placement_id":1234}}`)
+	assert.Equal(t, expectedJSON, appnexusExt)
 }
 
 func TestSetXandrVideoExt(t *testing.T) {
@@ -26,18 +20,15 @@ func TestSetXandrVideoExt(t *testing.T) {
 
 	video.Placement = openrtb2.VideoPlacementTypeInArticle
 	SetXandrVideoExt(video)
-	assert.NotNil(t, video.Ext)
-	var ext xandrVideoExt
-	json.Unmarshal(video.Ext, &ext)
-	assert.Equal(t, Outstream, ext.Appnexus.Context)
+	expectedVideoExt := json.RawMessage(`{"appnexus":{"context":4}}`)
+	assert.Equal(t, expectedVideoExt, video.Ext)
 
 	video.Ext = nil
 	video.Placement = openrtb2.VideoPlacementTypeInStream
 	video.StartDelay = openrtb2.StartDelayGenericPostRoll.Ptr()
 	SetXandrVideoExt(video)
-	assert.NotNil(t, video.Ext)
-	json.Unmarshal(video.Ext, &ext)
-	assert.Equal(t, PostRoll, ext.Appnexus.Context)
+	expectedVideoExt = json.RawMessage(`{"appnexus":{"context":3}}`)
+	assert.Equal(t, expectedVideoExt, video.Ext)
 }
 
 func TestGetXandrContext(t *testing.T) {

--- a/adapters/jwplayer/xandr_test.go
+++ b/adapters/jwplayer/xandr_test.go
@@ -1,0 +1,83 @@
+package jwplayer
+
+import (
+	"encoding/json"
+	"github.com/mxmCherry/openrtb/v15/openrtb2"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGetXandrImpExt(t *testing.T) {
+	appnexusExt := GetXandrImpExt("1234")
+	var appnexusImp xandrImpExt
+	json.Unmarshal(appnexusExt, &appnexusImp)
+	assert.Equal(t, 1234, appnexusImp.Appnexus.PlacementID)
+
+	var badAppnexusImp xandrImpExt
+	badAppnexusExt := GetXandrImpExt("-/")
+	json.Unmarshal(badAppnexusExt, &badAppnexusImp)
+	assert.Empty(t, badAppnexusImp)
+}
+
+func TestSetXandrVideoExt(t *testing.T) {
+	video := &openrtb2.Video{}
+	SetXandrVideoExt(video)
+	assert.Empty(t, video.Ext)
+
+	video.Placement = openrtb2.VideoPlacementTypeInArticle
+	SetXandrVideoExt(video)
+	assert.NotNil(t, video.Ext)
+	var ext xandrVideoExt
+	json.Unmarshal(video.Ext, &ext)
+	assert.Equal(t, Outstream, ext.Appnexus.Context)
+
+	video.Ext = nil
+	video.Placement = openrtb2.VideoPlacementTypeInStream
+	video.StartDelay = openrtb2.StartDelayGenericPostRoll.Ptr()
+	SetXandrVideoExt(video)
+	assert.NotNil(t, video.Ext)
+	json.Unmarshal(video.Ext, &ext)
+	assert.Equal(t, PostRoll, ext.Appnexus.Context)
+}
+
+func TestGetXandrContext(t *testing.T) {
+	video := openrtb2.Video{}
+	assert.Equal(t, Unknown, GetXandrContext(video))
+
+	video.Placement = openrtb2.VideoPlacementTypeInBanner
+	video.StartDelay = openrtb2.StartDelayPreRoll.Ptr()
+	assert.Equal(t, Outstream, GetXandrContext(video))
+
+	video.Placement = openrtb2.VideoPlacementTypeInStream
+	assert.Equal(t, PreRoll, GetXandrContext(video))
+}
+
+func TestGetXandrContextFromStartdelay(t *testing.T) {
+	assert.Equal(t, PreRoll, GetXandrContextFromStartdelay(openrtb2.StartDelayPreRoll))
+	assert.Equal(t, MidRoll, GetXandrContextFromStartdelay(openrtb2.StartDelayGenericMidRoll))
+	assert.Equal(t, MidRoll, GetXandrContextFromStartdelay(openrtb2.StartDelay(5)))
+	assert.Equal(t, PostRoll, GetXandrContextFromStartdelay(openrtb2.StartDelayGenericPostRoll))
+}
+
+func TestConvertToXandrKeywords(t *testing.T) {
+	var emptyJwpsegs []string
+	assert.Equal(t, "", ConvertToXandrKeywords(emptyJwpsegs))
+
+	singleJwpseg := []string{"80808080"}
+	assert.Equal(t, "jwpseg=80808080", ConvertToXandrKeywords(singleJwpseg))
+
+	multipleJwpsegs := []string{"88888888", "80808080", "80088008"}
+	assert.Equal(t, "jwpseg=88888888,jwpseg=80808080,jwpseg=80088008", ConvertToXandrKeywords(multipleJwpsegs))
+}
+
+func TestWriteToXandrKeywords(t *testing.T) {
+	keyword := "key=value"
+	var jwpsegs []string
+	WriteToXandrKeywords(&keyword, jwpsegs)
+	assert.Equal(t, "key=value", keyword)
+
+	jwpsegs = append(jwpsegs, "80808080")
+	WriteToXandrKeywords(&keyword, jwpsegs)
+	assert.Equal(t, "key=value,jwpseg=80808080", keyword)
+
+}

--- a/openrtb_ext/imp_jwplayer.go
+++ b/openrtb_ext/imp_jwplayer.go
@@ -2,5 +2,4 @@ package openrtb_ext
 
 type ImpExtJWPlayer struct {
 	PlacementId string `json:"placementId"`
-	PublisherId string `json:"publisherId,omitempty"`
 }

--- a/openrtb_ext/imp_jwplayer.go
+++ b/openrtb_ext/imp_jwplayer.go
@@ -1,5 +1,5 @@
 package openrtb_ext
 
 type ImpExtJWPlayer struct {
-	PlacementId string `json:"placementId"`
+	PlacementId string `json:"placementId,omitempty"`
 }


### PR DESCRIPTION
### Description

Since Xandr's API supports oRTB 2.4 and ours supports 2.5, we have to convert certain params in the bid request to xandr's Ext. 
This is the case for video.placement and video.startOffset, which map to video.ext.appnexus.context.

The PR also replaces the use of appnexus in our function and var names with xandr. 